### PR TITLE
Phase 1.2 — Skip-to-content link + focus-visible polish

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -10,3 +10,14 @@ body {
   color: #222222;
   font-family: var(--font-inter), sans-serif;
 }
+
+:focus-visible {
+  outline: 2px solid #222222;
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
+/* Invert focus ring on dark backgrounds (hero, mobile nav overlay) */
+.focus-ring-invert :focus-visible {
+  outline-color: #ffffff;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Playfair_Display, Inter } from "next/font/google";
 import "./globals.css";
+import SkipLink from "@/components/SkipLink";
 
 const playfair = Playfair_Display({
   variable: "--font-playfair",
@@ -28,6 +29,7 @@ export default function RootLayout({
       className={`${playfair.variable} ${inter.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col bg-white text-[#222222]">
+        <SkipLink />
         {children}
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,7 @@ export default function Home() {
   return (
     <>
       <Nav />
-      <main>
+      <main id="main" tabIndex={-1}>
         <Hero />
         <About />
         <ReelsPreview />

--- a/components/SkipLink.tsx
+++ b/components/SkipLink.tsx
@@ -1,0 +1,10 @@
+export default function SkipLink() {
+  return (
+    <a
+      href="#main"
+      className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:bg-white focus:text-[#222222] focus:font-medium focus:rounded focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-[#222222]"
+    >
+      Skip to content
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary

- New `components/SkipLink.tsx`: visually hidden until focused, links to `#main`, styled with a solid ring that works on white backgrounds
- `app/layout.tsx`: renders `<SkipLink />` as first child of `<body>`
- `app/page.tsx`: `<main>` gains `id="main" tabIndex={-1}` so programmatic focus lands correctly
- `app/globals.css`: global `:focus-visible` outline tokens (2px solid `#222`, 3px offset); `.focus-ring-invert` variant for dark-background surfaces (hero, mobile nav)

Closes #10

## Test plan

- [ ] Tab on the page — skip link appears at top-left and is focusable
- [ ] Activating the skip link moves focus to `<main>` and scrolls past the nav
- [ ] Tab through nav links — visible focus rings appear
- [ ] `npm run lint && npm run typecheck && npm run test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)