### PR TITLE
Phase 1.3 — Typography tuning

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -10,3 +10,12 @@ body {
   color: #222222;
   font-family: var(--font-inter), sans-serif;
 }
+
+h1,
+h2 {
+  text-wrap: balance;
+}
+
+.font-playfair {
+  letter-spacing: -0.01em;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,11 +5,13 @@ import "./globals.css";
 const playfair = Playfair_Display({
   variable: "--font-playfair",
   subsets: ["latin"],
+  weight: ["600", "700"],
 });
 
 const inter = Inter({
   variable: "--font-inter",
   subsets: ["latin"],
+  weight: ["300", "400", "500"],
 });
 
 export const metadata: Metadata = {


### PR DESCRIPTION
## Summary

- `layout.tsx`: Playfair Display subset to weights 600/700; Inter subset to 300/400/500 — reduces font payload by dropping unused weights
- `globals.css`: Playfair `.font-playfair` gets `letter-spacing: -0.01em` for tighter display rendering; `h1, h2` get `text-wrap: balance` to prevent awkward last-line orphans

Closes #11

## Test plan

- [ ] Headings reflow gracefully at narrow viewport widths
- [ ] Playfair display text looks tighter (nav title, section headings, hero name)
- [ ] `npm run lint && npm run typecheck && npm run test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)