### PR TITLE
Phase 1.4 — Site metadata + JSON-LD Person schema

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,9 +12,44 @@ const inter = Inter({
   subsets: ["latin"],
 });
 
+const siteUrl = "https://trappedactor.com";
+const ogImage = `${siteUrl}/og-image.png`;
+
 export const metadata: Metadata = {
-  title: "Smaran Harihar",
-  description: "Actor, Software Engineer, and Dad.",
+  metadataBase: new URL(siteUrl),
+  title: "Smaran Harihar — Actor",
+  description:
+    "Smaran Harihar is a Los Angeles-based actor. View his reel, headshots, and credits.",
+  alternates: { canonical: "/" },
+  openGraph: {
+    type: "profile",
+    siteName: "Smaran Harihar",
+    title: "Smaran Harihar — Actor",
+    description:
+      "Smaran Harihar is a Los Angeles-based actor. View his reel, headshots, and credits.",
+    url: siteUrl,
+    images: [{ url: ogImage, width: 1200, height: 630, alt: "Smaran Harihar" }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Smaran Harihar — Actor",
+    description:
+      "Smaran Harihar is a Los Angeles-based actor. View his reel, headshots, and credits.",
+    images: [ogImage],
+  },
+  themeColor: "#222222",
+};
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  name: "Smaran Harihar",
+  url: siteUrl,
+  jobTitle: "Actor",
+  sameAs: [
+    "https://www.imdb.com/name/nm13154667",
+    "https://www.instagram.com/trapped.actor",
+  ],
 };
 
 export default function RootLayout({
@@ -27,6 +62,12 @@ export default function RootLayout({
       lang="en"
       className={`${playfair.variable} ${inter.variable} h-full antialiased`}
     >
+      <head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </head>
       <body className="min-h-full flex flex-col bg-white text-[#222222]">
         {children}
       </body>


### PR DESCRIPTION
## Summary

- `layout.tsx`: expands `metadata` with `metadataBase`, `alternates.canonical`, full `openGraph` (profile type, title, description, url, siteName, image), full `twitter` (summary_large_image card), and `themeColor`
- Injects JSON-LD `Person` schema with name, jobTitle, url, and `sameAs` links (IMDB, Instagram)
- OG/Twitter image URLs point at `/og-image.png` (stub landing in #13)

Closes #12

## Test plan

- [ ] `view-source` on dev server shows `<meta property="og:title">`, `<meta name="twitter:card">`, and `<script type="application/ld+json">` in `<head>`
- [ ] JSON-LD is valid — paste into Google Rich Results Test or schema.org validator
- [ ] `npm run lint && npm run typecheck && npm run test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)