### PR TITLE
Phase 1.6 — Custom 404 page

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center px-6 text-center">
+      <p className="font-playfair text-[8rem] leading-none font-semibold text-[#222222] select-none">
+        404
+      </p>
+      <h1 className="mt-4 font-playfair text-2xl font-semibold text-[#222222]">
+        Page not found
+      </h1>
+      <p className="mt-3 text-sm text-[#666] max-w-xs">
+        The page you&apos;re looking for doesn&apos;t exist or has been moved.
+      </p>
+      <Link
+        href="/"
+        className="mt-8 inline-block text-sm tracking-widest uppercase text-[#222222] border-b border-[#222222] pb-0.5 hover:opacity-60 transition-opacity"
+      >
+        Back to home
+      </Link>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

- New `app/not-found.tsx`: site-styled 404 with Playfair Display "404" as a large display numeral, a heading, a short message, and an underline-style "Back to home" link
- Relies on typography from #18 (Playfair/Inter weight subsets)

Closes #14

## Test plan

- [ ] Navigate to `/nonexistent` on dev server — 404 page renders with site fonts
- [ ] "Back to home" link returns to `/`
- [ ] `npm run lint && npm run typecheck && npm run test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)