### PR TITLE
Phase 1.7 — Install Framer Motion + FadeInOnScroll wrapper

### DIFF
--- a/components/FadeInOnScroll.tsx
+++ b/components/FadeInOnScroll.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useReducedMotion, motion } from "framer-motion";
+
+interface FadeInOnScrollProps {
+  children: React.ReactNode;
+  className?: string;
+  delay?: number;
+}
+
+export default function FadeInOnScroll({
+  children,
+  className,
+  delay = 0,
+}: FadeInOnScrollProps) {
+  const reduced = useReducedMotion();
+
+  return (
+    <motion.div
+      className={className}
+      initial={reduced ? false : { opacity: 0, y: 24 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: "-60px" }}
+      transition={{ duration: 0.55, ease: "easeOut", delay }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "actor-portfolio-scaffold",
       "version": "0.1.0",
       "dependencies": {
+        "framer-motion": "^12.38.0",
         "next": "16.2.4",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -4721,6 +4722,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -6322,6 +6350,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
     },
     "node_modules/mrmime": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "framer-motion": "^12.38.0",
     "next": "16.2.4",
     "react": "19.2.4",
     "react-dom": "19.2.4"

--- a/tests/FadeInOnScroll.test.tsx
+++ b/tests/FadeInOnScroll.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import FadeInOnScroll from "../components/FadeInOnScroll";
+
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      className,
+    }: {
+      children: React.ReactNode;
+      className?: string;
+    }) => <div className={className}>{children}</div>,
+  },
+  useReducedMotion: () => false,
+}));
+
+describe("FadeInOnScroll", () => {
+  it("renders children", () => {
+    render(
+      <FadeInOnScroll>
+        <p>Hello world</p>
+      </FadeInOnScroll>
+    );
+    expect(screen.getByText("Hello world")).toBeInTheDocument();
+  });
+
+  it("passes className to wrapper", () => {
+    const { container } = render(
+      <FadeInOnScroll className="my-class">
+        <span>content</span>
+      </FadeInOnScroll>
+    );
+    expect(container.firstChild).toHaveClass("my-class");
+  });
+});


### PR DESCRIPTION
## Summary

- `npm install framer-motion`
- New `components/FadeInOnScroll.tsx`: client component using `motion.div` + `whileInView` (opacity 0 + y 24 → opacity 1 + y 0, 0.55s ease-out). Calls `useReducedMotion()` — when true, skips the initial hidden state entirely so no animation fires. The `prefers-reduced-motion` CSS guard from #16 is a second line of defense.
- New `tests/FadeInOnScroll.test.tsx`: smoke test that mocks framer-motion and confirms wrapped children render in the DOM

Depends on #16 (CSS reduced-motion guard) and #18 (typography, no functional dep)

Closes #15

## Test plan

- [ ] Scroll down the page — sections fade in from below
- [ ] With `Reduce motion` on in System Settings — sections appear immediately, no animation
- [ ] `npm run lint && npm run typecheck && npm run test` all pass (9 test files, 68 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)