### PR TITLE
feat(nav): scroll threshold 30px + glass state + active-section underline

### DIFF
--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -13,11 +13,31 @@ const links = [
 export default function Nav() {
   const [scrolled, setScrolled] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [activeSection, setActiveSection] = useState("");
 
   useEffect(() => {
-    const onScroll = () => setScrolled(window.scrollY > 0);
+    const onScroll = () => setScrolled(window.scrollY > 30);
     window.addEventListener("scroll", onScroll, { passive: true });
     return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  useEffect(() => {
+    const sections = document.querySelectorAll("section[id]");
+    if (sections.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setActiveSection(entry.target.id);
+          }
+        }
+      },
+      { threshold: 0.4, rootMargin: "-64px 0px 0px 0px" }
+    );
+
+    sections.forEach((section) => observer.observe(section));
+    return () => observer.disconnect();
   }, []);
 
   useEffect(() => {
@@ -31,7 +51,9 @@ export default function Nav() {
     <>
       <nav
         className={`fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-6 py-4 transition-all duration-300 ${
-          scrolled ? "bg-white shadow-sm" : "bg-transparent"
+          scrolled
+            ? "backdrop-blur-md bg-white/70 border-b border-black/5 shadow-sm"
+            : "bg-transparent"
         }`}
       >
         <Link
@@ -45,18 +67,24 @@ export default function Nav() {
 
         {/* Desktop links */}
         <ul className="hidden md:flex gap-8">
-          {links.map(({ label, href }) => (
-            <li key={href}>
-              <Link
-                href={href}
-                className={`text-sm tracking-widest uppercase ${
-                  scrolled ? "text-[#222222]" : "text-white"
-                } hover:opacity-60 transition-opacity`}
-              >
-                {label}
-              </Link>
-            </li>
-          ))}
+          {links.map(({ label, href }) => {
+            const sectionId = href.replace("/#", "");
+            const isActive = activeSection === sectionId;
+            return (
+              <li key={href}>
+                <Link
+                  href={href}
+                  className={`text-sm tracking-widest uppercase ${
+                    scrolled ? "text-[#222222]" : "text-white"
+                  } hover:opacity-60 transition-opacity ${
+                    isActive ? "border-b-2 border-current pb-0.5" : ""
+                  }`}
+                >
+                  {label}
+                </Link>
+              </li>
+            );
+          })}
         </ul>
 
         {/* Hamburger */}

--- a/tests/Nav.test.tsx
+++ b/tests/Nav.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import Nav from "../components/Nav";
 
 vi.mock("next/link", () => ({
@@ -67,23 +67,147 @@ describe("Nav — scroll state", () => {
 
   it("is transparent at top of page", () => {
     render(<Nav />);
-    expect(screen.getByRole("navigation").className).not.toMatch(/bg-white/);
+    expect(screen.getByRole("navigation").className).not.toMatch(
+      /backdrop-blur/
+    );
   });
 
-  it("gets white background after scrolling", () => {
+  it("stays transparent at scrollY = 30 (threshold boundary)", () => {
+    render(<Nav />);
+    Object.defineProperty(window, "scrollY", { writable: true, value: 30 });
+    fireEvent.scroll(window);
+    expect(screen.getByRole("navigation").className).not.toMatch(
+      /backdrop-blur/
+    );
+  });
+
+  it("shows glass state when scrollY > 30", () => {
+    render(<Nav />);
+    Object.defineProperty(window, "scrollY", { writable: true, value: 31 });
+    fireEvent.scroll(window);
+    const nav = screen.getByRole("navigation");
+    expect(nav.className).toMatch(/backdrop-blur/);
+    expect(nav.className).toMatch(/bg-white\/70/);
+  });
+
+  it("glass state includes hairline bottom border", () => {
     render(<Nav />);
     Object.defineProperty(window, "scrollY", { writable: true, value: 50 });
     fireEvent.scroll(window);
-    expect(screen.getByRole("navigation").className).toMatch(/bg-white/);
+    expect(screen.getByRole("navigation").className).toMatch(/border-black\/5/);
   });
 
-  it("returns to transparent when scrolled back to top", () => {
+  it("returns to transparent when scrolled back to ≤ 30", () => {
     render(<Nav />);
     Object.defineProperty(window, "scrollY", { writable: true, value: 50 });
     fireEvent.scroll(window);
     Object.defineProperty(window, "scrollY", { writable: true, value: 0 });
     fireEvent.scroll(window);
-    expect(screen.getByRole("navigation").className).not.toMatch(/bg-white/);
+    expect(screen.getByRole("navigation").className).not.toMatch(
+      /backdrop-blur/
+    );
+  });
+});
+
+describe("Nav — active-section underline", () => {
+  let observerCallback: (entries: Partial<IntersectionObserverEntry>[]) => void;
+  let observerInstance: {
+    observe: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
+    unobserve: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    observerInstance = {
+      observe: vi.fn(),
+      disconnect: vi.fn(),
+      unobserve: vi.fn(),
+    };
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        constructor(
+          cb: (entries: Partial<IntersectionObserverEntry>[]) => void
+        ) {
+          observerCallback = cb;
+          Object.assign(this, observerInstance);
+        }
+      }
+    );
+
+    // Create section elements for the observer to find
+    const sectionIds = ["about", "reels", "headshots", "contact"];
+    sectionIds.forEach((id) => {
+      const section = document.createElement("section");
+      section.id = id;
+      document.body.appendChild(section);
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.querySelectorAll("section[id]").forEach((el) => el.remove());
+  });
+
+  it("no link has active underline on initial render", () => {
+    render(<Nav />);
+    const desktopLinks = screen
+      .getAllByText("About Me")
+      .map((el) => el.closest("a"));
+    desktopLinks.forEach((link) => {
+      expect(link?.className).not.toMatch(/border-b-2/);
+    });
+  });
+
+  it("underlines the link whose section is in view", () => {
+    render(<Nav />);
+    act(() => {
+      observerCallback([
+        {
+          target: document.getElementById("about")!,
+          isIntersecting: true,
+          intersectionRatio: 0.5,
+        },
+      ]);
+    });
+    const aboutLinks = screen.getAllByText("About Me");
+    const desktopAbout = aboutLinks[0].closest("a");
+    expect(desktopAbout?.className).toMatch(/border-b-2/);
+  });
+
+  it("deactivates previous link when a new section enters view", () => {
+    render(<Nav />);
+    act(() => {
+      observerCallback([
+        {
+          target: document.getElementById("about")!,
+          isIntersecting: true,
+          intersectionRatio: 0.5,
+        },
+      ]);
+    });
+    act(() => {
+      observerCallback([
+        {
+          target: document.getElementById("reels")!,
+          isIntersecting: true,
+          intersectionRatio: 0.5,
+        },
+      ]);
+    });
+    const aboutLinks = screen.getAllByText("About Me");
+    const desktopAbout = aboutLinks[0].closest("a");
+    expect(desktopAbout?.className).not.toMatch(/border-b-2/);
+
+    const reelsLinks = screen.getAllByText("Reels");
+    const desktopReels = reelsLinks[0].closest("a");
+    expect(desktopReels?.className).toMatch(/border-b-2/);
+  });
+
+  it("disconnects observer on unmount", () => {
+    const { unmount } = render(<Nav />);
+    unmount();
+    expect(observerInstance.disconnect).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Closes #25

## Changes

### `components/Nav.tsx`
- Raise scroll threshold from `>0` to `>30` so transparent state is visible (N-01)
- Replace opaque `bg-white` with glass state: `backdrop-blur-md bg-white/70` + `border-b border-black/5` (N-03)
- Add `IntersectionObserver` for active-section underline on desktop nav links (N-08)
- Observer watches `section[id]` elements, underlines the link matching the currently visible section

### `tests/Nav.test.tsx`
- Update scroll state tests for 30px threshold and glass classes (5 tests)
- Add active-section underline tests: initial state, activation, deactivation, observer cleanup (4 tests)

## Test plan
- [x] `npm run lint && npm run typecheck && npm run test` — 122/122 pass