### PR TITLE
feat(nav): hamburger aria-expanded + animated bars → X

### DIFF
--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { motion, useReducedMotion } from "framer-motion";
 
 const links = [
   { label: "About Me", href: "/#about" },
@@ -14,6 +15,7 @@ export default function Nav() {
   const [scrolled, setScrolled] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [activeSection, setActiveSection] = useState("");
+  const reduced = useReducedMotion();
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 30);
@@ -87,20 +89,34 @@ export default function Nav() {
           })}
         </ul>
 
-        {/* Hamburger */}
+        {/* Hamburger — stays in DOM so aria-expanded is always readable */}
         <button
           aria-label="Open menu"
+          aria-expanded={menuOpen}
+          aria-controls="mobile-nav-overlay"
           className="md:hidden flex flex-col gap-1.5 p-1"
-          onClick={() => setMenuOpen(true)}
+          onClick={() => setMenuOpen((o) => !o)}
         >
-          <span
-            className={`block w-6 h-0.5 ${scrolled ? "bg-[#222222]" : "bg-white"}`}
+          <motion.span
+            className={`block w-6 h-0.5 origin-center ${
+              scrolled ? "bg-[#222222]" : "bg-white"
+            }`}
+            animate={menuOpen ? { rotate: 45, y: 8 } : { rotate: 0, y: 0 }}
+            transition={{ duration: reduced ? 0 : 0.3 }}
           />
-          <span
-            className={`block w-6 h-0.5 ${scrolled ? "bg-[#222222]" : "bg-white"}`}
+          <motion.span
+            className={`block w-6 h-0.5 ${
+              scrolled ? "bg-[#222222]" : "bg-white"
+            }`}
+            animate={menuOpen ? { opacity: 0 } : { opacity: 1 }}
+            transition={{ duration: reduced ? 0 : 0.3 }}
           />
-          <span
-            className={`block w-6 h-0.5 ${scrolled ? "bg-[#222222]" : "bg-white"}`}
+          <motion.span
+            className={`block w-6 h-0.5 origin-center ${
+              scrolled ? "bg-[#222222]" : "bg-white"
+            }`}
+            animate={menuOpen ? { rotate: -45, y: -8 } : { rotate: 0, y: 0 }}
+            transition={{ duration: reduced ? 0 : 0.3 }}
           />
         </button>
       </nav>
@@ -108,6 +124,7 @@ export default function Nav() {
       {/* Mobile full-screen overlay */}
       {menuOpen && (
         <div
+          id="mobile-nav-overlay"
           role="dialog"
           aria-modal="true"
           aria-label="Navigation menu"

--- a/tests/Nav.test.tsx
+++ b/tests/Nav.test.tsx
@@ -18,6 +18,31 @@ vi.mock("next/link", () => ({
   ),
 }));
 
+vi.mock("framer-motion", () => ({
+  motion: {
+    span: ({
+      children,
+      animate,
+      transition,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      animate?: Record<string, unknown>;
+      transition?: Record<string, unknown>;
+      [key: string]: unknown;
+    }) => (
+      <span
+        data-animate={JSON.stringify(animate)}
+        data-transition={JSON.stringify(transition)}
+        {...props}
+      >
+        {children}
+      </span>
+    ),
+  },
+  useReducedMotion: vi.fn(() => false),
+}));
+
 describe("Nav — links", () => {
   it("renders site name linking to /#", () => {
     render(<Nav />);
@@ -265,5 +290,84 @@ describe("Nav — mobile overlay", () => {
     expect(dialog).toHaveTextContent("Reels");
     expect(dialog).toHaveTextContent("Headshots");
     expect(dialog).toHaveTextContent("Contact");
+  });
+});
+
+describe("Nav — hamburger aria + animation", () => {
+  it("hamburger has aria-expanded=false by default", () => {
+    render(<Nav />);
+    expect(screen.getByLabelText("Open menu")).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+  });
+
+  it("hamburger has aria-expanded=true when overlay is open", () => {
+    render(<Nav />);
+    fireEvent.click(screen.getByLabelText("Open menu"));
+    expect(screen.getByLabelText("Open menu")).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+  });
+
+  it("hamburger has aria-controls pointing to overlay id", () => {
+    render(<Nav />);
+    const hamburger = screen.getByLabelText("Open menu");
+    expect(hamburger).toHaveAttribute("aria-controls", "mobile-nav-overlay");
+  });
+
+  it("overlay has id=mobile-nav-overlay", () => {
+    render(<Nav />);
+    fireEvent.click(screen.getByLabelText("Open menu"));
+    expect(document.getElementById("mobile-nav-overlay")).toBeInTheDocument();
+  });
+
+  it("hamburger renders 3 bar spans", () => {
+    render(<Nav />);
+    const button = screen.getByLabelText("Open menu");
+    expect(button.querySelectorAll("span")).toHaveLength(3);
+  });
+
+  it("middle bar has opacity:0 in animate when menu is open", () => {
+    render(<Nav />);
+    fireEvent.click(screen.getByLabelText("Open menu"));
+    const button = screen.getByLabelText("Open menu");
+    const bars = button.querySelectorAll("span");
+    const midAnimate = JSON.parse(bars[1].getAttribute("data-animate") ?? "{}");
+    expect(midAnimate.opacity).toBe(0);
+  });
+
+  it("top bar rotates to 45deg when menu is open", () => {
+    render(<Nav />);
+    fireEvent.click(screen.getByLabelText("Open menu"));
+    const button = screen.getByLabelText("Open menu");
+    const bars = button.querySelectorAll("span");
+    const topAnimate = JSON.parse(bars[0].getAttribute("data-animate") ?? "{}");
+    expect(topAnimate.rotate).toBe(45);
+  });
+
+  it("bottom bar rotates to -45deg when menu is open", () => {
+    render(<Nav />);
+    fireEvent.click(screen.getByLabelText("Open menu"));
+    const button = screen.getByLabelText("Open menu");
+    const bars = button.querySelectorAll("span");
+    const botAnimate = JSON.parse(bars[2].getAttribute("data-animate") ?? "{}");
+    expect(botAnimate.rotate).toBe(-45);
+  });
+
+  it("reduced motion: transition duration is 0", async () => {
+    // Must mock before render so useReducedMotion() returns true at init
+    const fm = await import("framer-motion");
+    vi.mocked(fm.useReducedMotion).mockReturnValue(true);
+    render(<Nav />);
+    fireEvent.click(screen.getByLabelText("Open menu"));
+    const button = screen.getByLabelText("Open menu");
+    const bars = button.querySelectorAll("span");
+    const transition = JSON.parse(
+      bars[0].getAttribute("data-transition") ?? "{}"
+    );
+    expect(transition.duration).toBe(0);
+    vi.mocked(fm.useReducedMotion).mockReturnValue(false); // restore
   });
 });


### PR DESCRIPTION
Closes #26

## Changes

### `components/Nav.tsx`
- `aria-expanded={menuOpen}` and `aria-controls="mobile-nav-overlay"` on hamburger (N-05)
- `id="mobile-nav-overlay"` on overlay div (N-05)
- Bars replaced with `motion.span`: top rotates 45°+y8, middle opacity→0, bottom rotates −45°+y−8 (N-04)
- Respects `useReducedMotion()` — transition `duration: 0` when preferred

### `tests/Nav.test.tsx`
- Added `vi.mock("framer-motion")` with `data-animate`/`data-transition` passthrough
- 8 new tests covering all acceptance criteria

## Test plan
- [x] 131/131 tests pass