### PR TITLE
feat(nav): focus-visible ring inversion on hero

### DIFF
--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -77,7 +77,7 @@ export default function Nav() {
         className={`fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-6 py-4 transition-all duration-300 ${
           scrolled
             ? "backdrop-blur-md bg-white/70 border-b border-black/5 shadow-sm"
-            : "bg-transparent"
+            : "bg-transparent focus-ring-invert"
         }`}
       >
         <Link

--- a/tests/Nav.test.tsx
+++ b/tests/Nav.test.tsx
@@ -132,6 +132,22 @@ describe("Nav — scroll state", () => {
       /backdrop-blur/
     );
   });
+
+  it("applies focus-ring-invert class when transparent (not scrolled)", () => {
+    render(<Nav />);
+    expect(screen.getByRole("navigation").className).toMatch(
+      /focus-ring-invert/
+    );
+  });
+
+  it("removes focus-ring-invert class when scrolled past threshold", () => {
+    render(<Nav />);
+    Object.defineProperty(window, "scrollY", { writable: true, value: 50 });
+    fireEvent.scroll(window);
+    expect(screen.getByRole("navigation").className).not.toMatch(
+      /focus-ring-invert/
+    );
+  });
 });
 
 describe("Nav — active-section underline", () => {


### PR DESCRIPTION
Closes #28

- Adds `focus-ring-invert` class to nav when transparent (top of page).
- Removes the class when scrolled.
- Added 2 tests.