### PR TITLE
chore(nav): document Home link omission per PRD

### DIFF
--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -4,6 +4,8 @@ import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { motion, useReducedMotion } from "framer-motion";
 
+// "Home" link intentionally omitted per PRD — the site title
+// ("Smaran Harihar") links to /# and serves as the home nav.
 const links = [
   { label: "About Me", href: "/#about" },
   { label: "Reels", href: "/#reels" },


### PR DESCRIPTION
Closes #29

- Adds a comment explaining the omission of the Home link, as it is handled by the site title.