### PR TITLE
feat(nav): Phase 2 Navigation Implementation

### DIFF
--- a/Plan/Phase-2.md
+++ b/Plan/Phase-2.md
@@ -1,0 +1,311 @@
+# Phase 2 — Nav (`components/Nav.tsx`)
+
+## Overview
+
+Polish and harden the fixed navigation bar. All work scoped to `components/Nav.tsx` and its test file `tests/Nav.test.tsx`. Uses Framer Motion (installed in Phase 1) for hamburger animation. Adds IntersectionObserver-driven active-section indicator.
+
+**QA-PLAN IDs addressed:** N-01, N-02, N-03, N-04, N-05, N-06, N-07, N-08.
+
+## Current state
+
+- `Nav.tsx` (110 lines) — fixed nav with transparent → white scroll state, hamburger, mobile overlay.
+- Scroll threshold is `> 0` (triggers immediately — bug N-01).
+- Scrolled state applies `bg-white shadow-sm` — no glass/blur effect (N-03).
+- Hamburger is three `<span>` bars — no animation to X (N-04).
+- Hamburger has `aria-label="Open menu"` but no `aria-expanded` (N-05).
+- Overlay has `aria-modal`, body scroll lock, close button, Esc-via-link-click dismiss — but no focus trap, no Esc keyboard handler, no focus restoration (N-06).
+- Links and site title rely on Phase 1 global `:focus-visible` — no nav-specific ring (N-07).
+- No active-section indicator (N-08).
+- No "Home" link — matches PRD intentionally (N-02).
+- **Section IDs available:** `#hero`, `#about`, `#reels`, `#headshots`, `#contact` (no `#stats` yet — that lands in Phase 7).
+
+## Slices
+
+### 2.1 — Fix scroll threshold + glass nav state
+
+**Type:** AFK
+**Blocked by:** None
+**QA IDs:** N-01, N-03
+
+#### What to build
+
+Raise the scroll threshold from `> 0` to `> 30` so the transparent-to-scrolled transition doesn't fire on sub-pixel scrolls. Replace the opaque `bg-white shadow-sm` scrolled state with a glass effect: `backdrop-blur-md bg-white/70` + `border-b border-black/5`.
+
+#### Behaviors to test (TDD)
+
+1. **Nav remains transparent when scrollY ≤ 30** — scroll to 10px, 20px, 30px → nav class should NOT contain `bg-white` or `backdrop-blur`.
+2. **Nav shows glass state when scrollY > 30** — scroll to 31px → nav class should contain `backdrop-blur` and `bg-white/70` and `border-b`.
+3. **Glass state includes hairline bottom border** — when scrolled, nav has `border-black/5` class.
+4. **Nav returns to transparent when scrolled back to ≤ 30** — scroll to 50px then back to 0 → transparent again.
+
+#### ⚠️ Existing test to update first
+
+Before writing new tests, update `tests/Nav.test.tsx`:
+
+- `"is transparent at top of page"` — currently asserts `.not.toMatch(/bg-white/)`. After this slice the scrolled class becomes `bg-white/70`, so this assertion still passes (transparent nav has no `bg-white` at all). **No change needed.**
+- `"gets white background after scrolling"` — currently asserts `.toMatch(/bg-white/)`. This will still match `bg-white/70` literally, but the intent is wrong; rename and tighten it: assert `.toMatch(/backdrop-blur/)` instead so it tracks the glass state rather than a partial string coincidence.
+- `"returns to transparent when scrolled back to top"` — currently asserts `.not.toMatch(/bg-white/)`. Still passes. **No change needed.**
+
+#### Implementation notes
+
+- In `Nav.tsx`, change `window.scrollY > 0` → `window.scrollY > 30`.
+- Replace scrolled class string:
+  - **Before:** `"bg-white shadow-sm"`
+  - **After:** `"backdrop-blur-md bg-white/70 border-b border-black/5 shadow-sm"`
+- Existing tests that use `value: 50` will still pass since 50 > 30.
+
+---
+
+### 2.2 — Hamburger `aria-expanded` + label flip
+
+**Type:** AFK
+**Blocked by:** None
+**QA IDs:** N-05
+
+#### What to build
+
+Add `aria-expanded` to the hamburger button that reflects menu state. When overlay is open, the hamburger should be hidden (since the overlay has its own close button), but if it were reachable its label would read "Close menu".
+
+Since the hamburger is only visible when the overlay is closed, the main change is adding `aria-expanded="false"` to the hamburger button. When the menu opens, it's replaced by the overlay anyway, so `aria-expanded` will always be `false` on the visible hamburger.
+
+However, to properly communicate state to assistive technology: when the overlay opens, we need to signal that the hamburger controls it. Add `aria-controls` pointing to the overlay's ID, and `aria-expanded={menuOpen}`.
+
+#### Behaviors to test (TDD)
+
+1. **Hamburger has `aria-expanded="false"` by default.**
+2. **Hamburger has `aria-expanded="true"` when menu is open** — this requires the hamburger to remain in the DOM even when overlay is shown (or test the attribute right before the overlay mounts).
+3. **Hamburger has `aria-controls` pointing to the overlay ID.**
+4. **Overlay has an `id` attribute** matching the `aria-controls` value.
+
+#### Implementation notes
+
+- Add `id="mobile-nav-overlay"` to the overlay `<div>`.
+- Add `aria-expanded={menuOpen}` and `aria-controls="mobile-nav-overlay"` to the hamburger `<button>`.
+- The hamburger remains in the DOM behind the overlay (it's in the `<nav>` which is z-50, overlay is also z-50 but positioned over it).
+
+---
+
+### 2.3 — Animated hamburger bars → X (Framer Motion)
+
+**Type:** AFK
+**Blocked by:** 2.2
+**QA IDs:** N-04
+
+#### What to build
+
+Replace the three static `<span>` bars with Framer Motion `motion.span` elements that animate into an X when `menuOpen` is true. The three bars morph: top bar rotates 45°, middle bar fades out, bottom bar rotates -45°. Honors `prefers-reduced-motion` (instant state change, no animation).
+
+#### Behaviors to test (TDD)
+
+1. **Hamburger renders 3 bars when menu is closed** — the button contains 3 child `<span>` elements.
+2. **Bars transform into X shape when menu opens** — verify the presence of rotation styles or animate props. Since Framer Motion is mocked in tests, verify the mock receives the expected `animate` props (or test the rendered data attributes).
+3. **Reduced-motion: bars switch state without animation** — when `useReducedMotion()` returns true, the transition duration is 0 (or `initial` is used instead of `animate`).
+
+#### ⚠️ Test file mock required
+
+`Nav.test.tsx` does not currently mock `framer-motion`. When slice 2.3 ships, any test that renders `Nav` will fail at import time with `motion is not defined` unless the mock is added. Add this block at the top of the test file (alongside the existing `next/link` mock):
+
+```ts
+vi.mock("framer-motion", () => ({
+  motion: {
+    span: ({ children, animate, ...props }: {
+      children?: React.ReactNode;
+      animate?: Record<string, unknown>;
+      [key: string]: unknown;
+    }) => <span data-animate={JSON.stringify(animate)} {...props}>{children}</span>,
+  },
+  useReducedMotion: vi.fn(() => false),
+}));
+```
+
+This lets tests assert on the `data-animate` attribute to verify bar rotation/opacity values without running actual Framer Motion.
+
+#### Implementation notes
+
+- Import `motion, useReducedMotion` from `framer-motion`.
+- `"use client"` is already present.
+- Replace `<span>` with `<motion.span>` for the three bars.
+- Animate based on `menuOpen`:
+  - Bar 1: `rotate: menuOpen ? 45 : 0`, `translateY: menuOpen ? 8 : 0`
+  - Bar 2: `opacity: menuOpen ? 0 : 1`
+  - Bar 3: `rotate: menuOpen ? -45 : 0`, `translateY: menuOpen ? -8 : 0`
+- Set `transition: { duration: reduced ? 0 : 0.3 }`.
+- The hamburger button must stay in the DOM when menu is open (don't conditionally remove it); it just sits behind the overlay.
+
+---
+
+### 2.4 — Focus trap + Esc handler + focus restoration on mobile overlay
+
+**Type:** AFK
+**Blocked by:** None
+**QA IDs:** N-06
+
+#### What to build
+
+When the mobile overlay opens:
+
+1. Move focus to the first focusable element (the close button).
+2. Trap Tab/Shift+Tab within the overlay (wrap around from last link → close button and vice versa).
+3. Pressing Escape closes the overlay.
+4. On close, restore focus to the hamburger button.
+
+#### Behaviors to test (TDD)
+
+1. **Focus moves to close button when overlay opens** — after clicking hamburger, `document.activeElement` should be the close button.
+2. **Escape key closes overlay** — keyDown Escape on overlay → overlay removed from DOM.
+3. **Focus returns to hamburger after closing overlay** — after closing via Esc or close button, `document.activeElement` should be the hamburger button.
+4. **Tab from last link wraps to close button** — focus the last link ("Contact"), press Tab → focus lands on close button.
+5. **Shift+Tab from close button wraps to last link** — focus the close button, press Shift+Tab → focus lands on last link.
+
+#### Implementation notes
+
+- Give the hamburger button a `ref` so focus can be restored: `const hamburgerRef = useRef<HTMLButtonElement>(null)`.
+- Give the close button a `ref` and call `closeRef.current?.focus()` in a `useEffect` that runs when `menuOpen` becomes true.
+- Add a `useEffect` for the Escape keydown listener when `menuOpen` is true.
+- Implement focus trap: on `keydown` of Tab within the overlay, check if focus is on the last focusable element and wrap to first (and vice versa for Shift+Tab).
+- On close, call `hamburgerRef.current?.focus()`.
+
+---
+
+### 2.5 — Nav link focus-visible rings
+
+**Type:** AFK
+**Blocked by:** None
+**QA IDs:** N-07
+
+#### What to build
+
+Ensure all nav links and the site title have visible, well-contrasted `:focus-visible` outlines. On the hero (transparent nav), rings should be white; on scrolled nav, rings should be dark. The Phase 1 global `.focus-ring-invert` class handles inversion, but nav needs to apply it correctly based on scroll state.
+
+#### Behaviors to test (TDD)
+
+1. **Nav bar applies `focus-ring-invert` class when transparent (not scrolled)** — at the top of page, nav should have the `focus-ring-invert` class so focus rings appear white on the dark hero.
+2. **Nav bar removes `focus-ring-invert` class when scrolled** — after scrolling past threshold, the class is removed so focus rings appear dark on white background.
+
+#### Implementation notes
+
+- Add `focus-ring-invert` to the nav's className when `!scrolled`.
+- Remove it when `scrolled`.
+- The global CSS already defines `.focus-ring-invert :focus-visible { outline-color: #ffffff }`, so no CSS changes needed.
+
+---
+
+### 2.6 — IntersectionObserver active-section underline
+
+**Type:** AFK
+**Blocked by:** 2.1
+**QA IDs:** N-08
+
+#### What to build
+
+As the user scrolls, the desktop nav link corresponding to the currently visible section gets a subtle underline indicator. Uses `IntersectionObserver` to detect which section (`#about`, `#reels`, `#headshots`, `#contact`) is in view.
+
+#### ⚠️ IntersectionObserver stub required
+
+JSDOM does not implement `IntersectionObserver`. Any test that renders `Nav` after this slice ships will throw `IntersectionObserver is not defined` unless stubbed. Add the following to `tests/setup.ts` (runs globally before every test file):
+
+```ts
+const mockObserve = vi.fn();
+const mockDisconnect = vi.fn();
+let intersectionCallback: IntersectionObserverCallback;
+
+vi.stubGlobal(
+  "IntersectionObserver",
+  vi.fn((cb: IntersectionObserverCallback) => {
+    intersectionCallback = cb;
+    return { observe: mockObserve, disconnect: mockDisconnect };
+  })
+);
+
+// Expose helper for tests that need to simulate intersection
+export const triggerIntersection = (id: string, isIntersecting = true) => {
+  intersectionCallback(
+    [
+      {
+        target: { id },
+        isIntersecting,
+      } as unknown as IntersectionObserverEntry,
+    ],
+    {} as IntersectionObserver
+  );
+};
+```
+
+Tests that verify active-section behavior import `triggerIntersection` from `setup.ts` and call it to simulate a section entering the viewport. Tests that only render `Nav` for other assertions (links, scroll state, overlay) need no changes — the stub silently provides the interface without triggering callbacks.
+
+#### Behaviors to test (TDD)
+
+1. **No link is active on initial render** — no link has the active underline class.
+2. **Link becomes active when its section is in view** — call `triggerIntersection("about")` → the "About Me" link gets the active class (e.g., `border-b-2 border-current`).
+3. **Previously active link deactivates when another section enters view** — call `triggerIntersection("reels")` after "about" was active → "About Me" loses active class, "Reels" gains it.
+4. **Active underline is hidden on mobile** — the underline only applies to `hidden md:flex` desktop links (the `<ul>` list), not to overlay links.
+
+#### Implementation notes
+
+- Add state: `const [activeSection, setActiveSection] = useState("")`.
+- Add a `useEffect` that creates an `IntersectionObserver` observing all section elements (`document.querySelectorAll("section[id]")`), with `threshold: 0.4` and `rootMargin: "-64px 0px 0px 0px"` (nav height offset).
+- On intersection, set `activeSection` to the `id` of the intersecting entry.
+- In the desktop link render, conditionally add a bottom border class when `link.href` contains the active section:
+  ```
+  const isActive = activeSection && href.includes(activeSection);
+  className += isActive ? " border-b-2 border-current" : "";
+  ```
+- Disconnect observer on unmount.
+
+---
+
+### 2.7 — Document "Home" link omission
+
+**Type:** AFK
+**Blocked by:** None
+**QA IDs:** N-02
+
+#### What to build
+
+Add a code comment in `Nav.tsx` confirming that the "Home" link is intentionally omitted per the PRD. The site title "Smaran Harihar" links to `/#`, which serves as the home navigation.
+
+#### Behaviors to test (TDD)
+
+No tests needed — this is a documentation-only change.
+
+#### Implementation notes
+
+- Add a comment above the `links` array:
+  ```ts
+  // "Home" link intentionally omitted per PRD — the site title
+  // ("Smaran Harihar") links to /# and serves as the home nav.
+  ```
+
+## Suggested slice order for /to-issues
+
+Create issues in this order so blockers land first:
+
+1. **2.1** — Scroll threshold + glass nav (no blockers)
+2. **2.2** — Hamburger aria-expanded + label flip (no blockers)
+3. **2.4** — Focus trap + Esc + focus restoration (no blockers)
+4. **2.5** — Focus-visible rings (no blockers)
+5. **2.7** — Document Home link omission (no blockers)
+6. **2.3** — Animated hamburger (blocked by 2.2)
+7. **2.6** — Active-section underline (blocked by 2.1)
+
+## Files touched
+
+| File                 | Changes                                                                     |
+| -------------------- | --------------------------------------------------------------------------- |
+| `components/Nav.tsx` | All slices modify this file                                                 |
+| `tests/Nav.test.tsx` | New and updated tests for slices 2.1–2.6                                    |
+| `app/globals.css`    | No changes expected (Phase 1 already has focus-visible + focus-ring-invert) |
+
+## Verification gate
+
+From QA-PLAN.md:
+
+1. `npm run lint && npm run typecheck && npm run test` all pass.
+2. `npm run dev` manual walkthrough:
+   - Scroll past 30px → glass nav appears with blur + hairline border.
+   - Tab through links → focus rings visible (white on hero, dark on scrolled).
+   - Mobile hamburger → animated X transition.
+   - Mobile menu Esc closes + restores focus to hamburger.
+   - Active-section underline updates as you scroll down the page.
+3. `git diff` reviewed; conventional-commit subject: `feat(nav): glassy scroll state + a11y polish`.
+4. Opens its own PR for review.

--- a/Plan/QA-PLAN.md
+++ b/Plan/QA-PLAN.md
@@ -34,7 +34,7 @@ _(items explicitly punted by the user; tracked here so they aren't lost)_
 
 Each phase is a standalone, shippable PR. All references like `N-01`, `H-02` map to IDs in `QA-PLAN.md`. Items marked **(pulled forward)** are lower-severity items bundled in to avoid re-editing the same file later (per D4).
 
-### Phase 1 — Foundation / cross-cutting
+### Phase 1 — Foundation / cross-cutting ✅ Done
 
 **Files:** `app/layout.tsx`, `app/globals.css`, `app/not-found.tsx` (new), `public/` (favicon stubs, og-image stub), `package.json` (Framer Motion), `components/SkipLink.tsx` (new), `components/FadeInOnScroll.tsx` (new).
 

--- a/Plan/QA-PLAN.md
+++ b/Plan/QA-PLAN.md
@@ -100,7 +100,7 @@ Phase 1 is broken into **7 GitHub issues** (vertical slices). Items in the same 
 - Used by Phases 3–8.
 - IDs: G-01, G-08 enforcement.
 
-### Phase 2 — Nav (`components/Nav.tsx`)
+### Phase 2 — Nav (`components/Nav.tsx`) ✅ Done
 
 - **Bug:** raise scroll threshold to ~30px so transparent state is actually visible (N-01).
 - Glass intermediate state: `backdrop-blur-md bg-white/70` + hairline `border-b border-black/5` once scrolled (N-03).

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { motion, useReducedMotion } from "framer-motion";
 
 const links = [
   { label: "About Me", href: "/#about" },
@@ -14,6 +15,7 @@ export default function Nav() {
   const [scrolled, setScrolled] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [activeSection, setActiveSection] = useState("");
+  const reduced = useReducedMotion();
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 30);
@@ -87,20 +89,34 @@ export default function Nav() {
           })}
         </ul>
 
-        {/* Hamburger */}
+        {/* Hamburger — stays in DOM so aria-expanded is always readable */}
         <button
           aria-label="Open menu"
+          aria-expanded={menuOpen}
+          aria-controls="mobile-nav-overlay"
           className="md:hidden flex flex-col gap-1.5 p-1"
-          onClick={() => setMenuOpen(true)}
+          onClick={() => setMenuOpen((o) => !o)}
         >
-          <span
-            className={`block w-6 h-0.5 ${scrolled ? "bg-[#222222]" : "bg-white"}`}
+          <motion.span
+            className={`block w-6 h-0.5 origin-center ${
+              scrolled ? "bg-[#222222]" : "bg-white"
+            }`}
+            animate={menuOpen ? { rotate: 45, y: 8 } : { rotate: 0, y: 0 }}
+            transition={{ duration: reduced ? 0 : 0.3 }}
           />
-          <span
-            className={`block w-6 h-0.5 ${scrolled ? "bg-[#222222]" : "bg-white"}`}
+          <motion.span
+            className={`block w-6 h-0.5 ${
+              scrolled ? "bg-[#222222]" : "bg-white"
+            }`}
+            animate={menuOpen ? { opacity: 0 } : { opacity: 1 }}
+            transition={{ duration: reduced ? 0 : 0.3 }}
           />
-          <span
-            className={`block w-6 h-0.5 ${scrolled ? "bg-[#222222]" : "bg-white"}`}
+          <motion.span
+            className={`block w-6 h-0.5 origin-center ${
+              scrolled ? "bg-[#222222]" : "bg-white"
+            }`}
+            animate={menuOpen ? { rotate: -45, y: -8 } : { rotate: 0, y: 0 }}
+            transition={{ duration: reduced ? 0 : 0.3 }}
           />
         </button>
       </nav>
@@ -108,6 +124,7 @@ export default function Nav() {
       {/* Mobile full-screen overlay */}
       {menuOpen && (
         <div
+          id="mobile-nav-overlay"
           role="dialog"
           aria-modal="true"
           aria-label="Navigation menu"

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -77,7 +77,7 @@ export default function Nav() {
         className={`fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-6 py-4 transition-all duration-300 ${
           scrolled
             ? "backdrop-blur-md bg-white/70 border-b border-black/5 shadow-sm"
-            : "bg-transparent"
+            : "bg-transparent focus-ring-invert"
         }`}
       >
         <Link

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { motion, useReducedMotion } from "framer-motion";
 
@@ -16,6 +16,8 @@ export default function Nav() {
   const [menuOpen, setMenuOpen] = useState(false);
   const [activeSection, setActiveSection] = useState("");
   const reduced = useReducedMotion();
+  const hamburgerRef = useRef<HTMLButtonElement>(null);
+  const closeBtnRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 30);
@@ -47,6 +49,26 @@ export default function Nav() {
     return () => {
       document.body.style.overflow = "";
     };
+  }, [menuOpen]);
+
+  // Focus close button when overlay opens
+  useEffect(() => {
+    if (menuOpen) {
+      closeBtnRef.current?.focus();
+    }
+  }, [menuOpen]);
+
+  // Escape key closes overlay and restores focus
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setMenuOpen(false);
+        hamburgerRef.current?.focus();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
   }, [menuOpen]);
 
   return (
@@ -91,6 +113,7 @@ export default function Nav() {
 
         {/* Hamburger — stays in DOM so aria-expanded is always readable */}
         <button
+          ref={hamburgerRef}
           aria-label="Open menu"
           aria-expanded={menuOpen}
           aria-controls="mobile-nav-overlay"
@@ -131,9 +154,13 @@ export default function Nav() {
           className="fixed inset-0 z-50 bg-white flex flex-col items-center justify-center gap-10"
         >
           <button
+            ref={closeBtnRef}
             aria-label="Close menu"
             className="absolute top-5 right-6 text-3xl text-[#222222]"
-            onClick={() => setMenuOpen(false)}
+            onClick={() => {
+              setMenuOpen(false);
+              hamburgerRef.current?.focus();
+            }}
           >
             &times;
           </button>

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -4,6 +4,8 @@ import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { motion, useReducedMotion } from "framer-motion";
 
+// "Home" link intentionally omitted per PRD — the site title
+// ("Smaran Harihar") links to /# and serves as the home nav.
 const links = [
   { label: "About Me", href: "/#about" },
   { label: "Reels", href: "/#reels" },

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -13,11 +13,31 @@ const links = [
 export default function Nav() {
   const [scrolled, setScrolled] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [activeSection, setActiveSection] = useState("");
 
   useEffect(() => {
-    const onScroll = () => setScrolled(window.scrollY > 0);
+    const onScroll = () => setScrolled(window.scrollY > 30);
     window.addEventListener("scroll", onScroll, { passive: true });
     return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  useEffect(() => {
+    const sections = document.querySelectorAll("section[id]");
+    if (sections.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setActiveSection(entry.target.id);
+          }
+        }
+      },
+      { threshold: 0.4, rootMargin: "-64px 0px 0px 0px" }
+    );
+
+    sections.forEach((section) => observer.observe(section));
+    return () => observer.disconnect();
   }, []);
 
   useEffect(() => {
@@ -31,7 +51,9 @@ export default function Nav() {
     <>
       <nav
         className={`fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-6 py-4 transition-all duration-300 ${
-          scrolled ? "bg-white shadow-sm" : "bg-transparent"
+          scrolled
+            ? "backdrop-blur-md bg-white/70 border-b border-black/5 shadow-sm"
+            : "bg-transparent"
         }`}
       >
         <Link
@@ -45,18 +67,24 @@ export default function Nav() {
 
         {/* Desktop links */}
         <ul className="hidden md:flex gap-8">
-          {links.map(({ label, href }) => (
-            <li key={href}>
-              <Link
-                href={href}
-                className={`text-sm tracking-widest uppercase ${
-                  scrolled ? "text-[#222222]" : "text-white"
-                } hover:opacity-60 transition-opacity`}
-              >
-                {label}
-              </Link>
-            </li>
-          ))}
+          {links.map(({ label, href }) => {
+            const sectionId = href.replace("/#", "");
+            const isActive = activeSection === sectionId;
+            return (
+              <li key={href}>
+                <Link
+                  href={href}
+                  className={`text-sm tracking-widest uppercase ${
+                    scrolled ? "text-[#222222]" : "text-white"
+                  } hover:opacity-60 transition-opacity ${
+                    isActive ? "border-b-2 border-current pb-0.5" : ""
+                  }`}
+                >
+                  {label}
+                </Link>
+              </li>
+            );
+          })}
         </ul>
 
         {/* Hamburger */}

--- a/tests/Nav.test.tsx
+++ b/tests/Nav.test.tsx
@@ -132,6 +132,22 @@ describe("Nav — scroll state", () => {
       /backdrop-blur/
     );
   });
+
+  it("applies focus-ring-invert class when transparent (not scrolled)", () => {
+    render(<Nav />);
+    expect(screen.getByRole("navigation").className).toMatch(
+      /focus-ring-invert/
+    );
+  });
+
+  it("removes focus-ring-invert class when scrolled past threshold", () => {
+    render(<Nav />);
+    Object.defineProperty(window, "scrollY", { writable: true, value: 50 });
+    fireEvent.scroll(window);
+    expect(screen.getByRole("navigation").className).not.toMatch(
+      /focus-ring-invert/
+    );
+  });
 });
 
 describe("Nav — active-section underline", () => {

--- a/tests/Nav.test.tsx
+++ b/tests/Nav.test.tsx
@@ -18,6 +18,31 @@ vi.mock("next/link", () => ({
   ),
 }));
 
+vi.mock("framer-motion", () => ({
+  motion: {
+    span: ({
+      children,
+      animate,
+      transition,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      animate?: Record<string, unknown>;
+      transition?: Record<string, unknown>;
+      [key: string]: unknown;
+    }) => (
+      <span
+        data-animate={JSON.stringify(animate)}
+        data-transition={JSON.stringify(transition)}
+        {...props}
+      >
+        {children}
+      </span>
+    ),
+  },
+  useReducedMotion: vi.fn(() => false),
+}));
+
 describe("Nav — links", () => {
   it("renders site name linking to /#", () => {
     render(<Nav />);
@@ -265,5 +290,84 @@ describe("Nav — mobile overlay", () => {
     expect(dialog).toHaveTextContent("Reels");
     expect(dialog).toHaveTextContent("Headshots");
     expect(dialog).toHaveTextContent("Contact");
+  });
+});
+
+describe("Nav — hamburger aria + animation", () => {
+  it("hamburger has aria-expanded=false by default", () => {
+    render(<Nav />);
+    expect(screen.getByLabelText("Open menu")).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+  });
+
+  it("hamburger has aria-expanded=true when overlay is open", () => {
+    render(<Nav />);
+    fireEvent.click(screen.getByLabelText("Open menu"));
+    expect(screen.getByLabelText("Open menu")).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+  });
+
+  it("hamburger has aria-controls pointing to overlay id", () => {
+    render(<Nav />);
+    const hamburger = screen.getByLabelText("Open menu");
+    expect(hamburger).toHaveAttribute("aria-controls", "mobile-nav-overlay");
+  });
+
+  it("overlay has id=mobile-nav-overlay", () => {
+    render(<Nav />);
+    fireEvent.click(screen.getByLabelText("Open menu"));
+    expect(document.getElementById("mobile-nav-overlay")).toBeInTheDocument();
+  });
+
+  it("hamburger renders 3 bar spans", () => {
+    render(<Nav />);
+    const button = screen.getByLabelText("Open menu");
+    expect(button.querySelectorAll("span")).toHaveLength(3);
+  });
+
+  it("middle bar has opacity:0 in animate when menu is open", () => {
+    render(<Nav />);
+    fireEvent.click(screen.getByLabelText("Open menu"));
+    const button = screen.getByLabelText("Open menu");
+    const bars = button.querySelectorAll("span");
+    const midAnimate = JSON.parse(bars[1].getAttribute("data-animate") ?? "{}");
+    expect(midAnimate.opacity).toBe(0);
+  });
+
+  it("top bar rotates to 45deg when menu is open", () => {
+    render(<Nav />);
+    fireEvent.click(screen.getByLabelText("Open menu"));
+    const button = screen.getByLabelText("Open menu");
+    const bars = button.querySelectorAll("span");
+    const topAnimate = JSON.parse(bars[0].getAttribute("data-animate") ?? "{}");
+    expect(topAnimate.rotate).toBe(45);
+  });
+
+  it("bottom bar rotates to -45deg when menu is open", () => {
+    render(<Nav />);
+    fireEvent.click(screen.getByLabelText("Open menu"));
+    const button = screen.getByLabelText("Open menu");
+    const bars = button.querySelectorAll("span");
+    const botAnimate = JSON.parse(bars[2].getAttribute("data-animate") ?? "{}");
+    expect(botAnimate.rotate).toBe(-45);
+  });
+
+  it("reduced motion: transition duration is 0", async () => {
+    // Must mock before render so useReducedMotion() returns true at init
+    const fm = await import("framer-motion");
+    vi.mocked(fm.useReducedMotion).mockReturnValue(true);
+    render(<Nav />);
+    fireEvent.click(screen.getByLabelText("Open menu"));
+    const button = screen.getByLabelText("Open menu");
+    const bars = button.querySelectorAll("span");
+    const transition = JSON.parse(
+      bars[0].getAttribute("data-transition") ?? "{}"
+    );
+    expect(transition.duration).toBe(0);
+    vi.mocked(fm.useReducedMotion).mockReturnValue(false); // restore
   });
 });

--- a/tests/Nav.test.tsx
+++ b/tests/Nav.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import Nav from "../components/Nav";
 
 vi.mock("next/link", () => ({
@@ -67,23 +67,147 @@ describe("Nav — scroll state", () => {
 
   it("is transparent at top of page", () => {
     render(<Nav />);
-    expect(screen.getByRole("navigation").className).not.toMatch(/bg-white/);
+    expect(screen.getByRole("navigation").className).not.toMatch(
+      /backdrop-blur/
+    );
   });
 
-  it("gets white background after scrolling", () => {
+  it("stays transparent at scrollY = 30 (threshold boundary)", () => {
+    render(<Nav />);
+    Object.defineProperty(window, "scrollY", { writable: true, value: 30 });
+    fireEvent.scroll(window);
+    expect(screen.getByRole("navigation").className).not.toMatch(
+      /backdrop-blur/
+    );
+  });
+
+  it("shows glass state when scrollY > 30", () => {
+    render(<Nav />);
+    Object.defineProperty(window, "scrollY", { writable: true, value: 31 });
+    fireEvent.scroll(window);
+    const nav = screen.getByRole("navigation");
+    expect(nav.className).toMatch(/backdrop-blur/);
+    expect(nav.className).toMatch(/bg-white\/70/);
+  });
+
+  it("glass state includes hairline bottom border", () => {
     render(<Nav />);
     Object.defineProperty(window, "scrollY", { writable: true, value: 50 });
     fireEvent.scroll(window);
-    expect(screen.getByRole("navigation").className).toMatch(/bg-white/);
+    expect(screen.getByRole("navigation").className).toMatch(/border-black\/5/);
   });
 
-  it("returns to transparent when scrolled back to top", () => {
+  it("returns to transparent when scrolled back to ≤ 30", () => {
     render(<Nav />);
     Object.defineProperty(window, "scrollY", { writable: true, value: 50 });
     fireEvent.scroll(window);
     Object.defineProperty(window, "scrollY", { writable: true, value: 0 });
     fireEvent.scroll(window);
-    expect(screen.getByRole("navigation").className).not.toMatch(/bg-white/);
+    expect(screen.getByRole("navigation").className).not.toMatch(
+      /backdrop-blur/
+    );
+  });
+});
+
+describe("Nav — active-section underline", () => {
+  let observerCallback: (entries: Partial<IntersectionObserverEntry>[]) => void;
+  let observerInstance: {
+    observe: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
+    unobserve: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    observerInstance = {
+      observe: vi.fn(),
+      disconnect: vi.fn(),
+      unobserve: vi.fn(),
+    };
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        constructor(
+          cb: (entries: Partial<IntersectionObserverEntry>[]) => void
+        ) {
+          observerCallback = cb;
+          Object.assign(this, observerInstance);
+        }
+      }
+    );
+
+    // Create section elements for the observer to find
+    const sectionIds = ["about", "reels", "headshots", "contact"];
+    sectionIds.forEach((id) => {
+      const section = document.createElement("section");
+      section.id = id;
+      document.body.appendChild(section);
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.querySelectorAll("section[id]").forEach((el) => el.remove());
+  });
+
+  it("no link has active underline on initial render", () => {
+    render(<Nav />);
+    const desktopLinks = screen
+      .getAllByText("About Me")
+      .map((el) => el.closest("a"));
+    desktopLinks.forEach((link) => {
+      expect(link?.className).not.toMatch(/border-b-2/);
+    });
+  });
+
+  it("underlines the link whose section is in view", () => {
+    render(<Nav />);
+    act(() => {
+      observerCallback([
+        {
+          target: document.getElementById("about")!,
+          isIntersecting: true,
+          intersectionRatio: 0.5,
+        },
+      ]);
+    });
+    const aboutLinks = screen.getAllByText("About Me");
+    const desktopAbout = aboutLinks[0].closest("a");
+    expect(desktopAbout?.className).toMatch(/border-b-2/);
+  });
+
+  it("deactivates previous link when a new section enters view", () => {
+    render(<Nav />);
+    act(() => {
+      observerCallback([
+        {
+          target: document.getElementById("about")!,
+          isIntersecting: true,
+          intersectionRatio: 0.5,
+        },
+      ]);
+    });
+    act(() => {
+      observerCallback([
+        {
+          target: document.getElementById("reels")!,
+          isIntersecting: true,
+          intersectionRatio: 0.5,
+        },
+      ]);
+    });
+    const aboutLinks = screen.getAllByText("About Me");
+    const desktopAbout = aboutLinks[0].closest("a");
+    expect(desktopAbout?.className).not.toMatch(/border-b-2/);
+
+    const reelsLinks = screen.getAllByText("Reels");
+    const desktopReels = reelsLinks[0].closest("a");
+    expect(desktopReels?.className).toMatch(/border-b-2/);
+  });
+
+  it("disconnects observer on unmount", () => {
+    const { unmount } = render(<Nav />);
+    unmount();
+    expect(observerInstance.disconnect).toHaveBeenCalled();
   });
 });
 

--- a/tests/Nav.test.tsx
+++ b/tests/Nav.test.tsx
@@ -371,3 +371,34 @@ describe("Nav — hamburger aria + animation", () => {
     vi.mocked(fm.useReducedMotion).mockReturnValue(false); // restore
   });
 });
+
+describe("Nav — focus trap + Esc + focus restoration", () => {
+  it("focus moves to close button when overlay opens", () => {
+    render(<Nav />);
+    fireEvent.click(screen.getByLabelText("Open menu"));
+    expect(document.activeElement).toBe(screen.getByLabelText("Close menu"));
+  });
+
+  it("Escape key closes the overlay", () => {
+    render(<Nav />);
+    fireEvent.click(screen.getByLabelText("Open menu"));
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("focus returns to hamburger after closing via close button", () => {
+    render(<Nav />);
+    const hamburger = screen.getByLabelText("Open menu");
+    fireEvent.click(hamburger);
+    fireEvent.click(screen.getByLabelText("Close menu"));
+    expect(document.activeElement).toBe(hamburger);
+  });
+
+  it("focus returns to hamburger after closing via Escape", () => {
+    render(<Nav />);
+    const hamburger = screen.getByLabelText("Open menu");
+    fireEvent.click(hamburger);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(document.activeElement).toBe(hamburger);
+  });
+});


### PR DESCRIPTION
This PR merges the completed Phase 2 navigation features into main.

Closes #25
Closes #26
Closes #27
Closes #28
Closes #29

### Highlights:
- **N-01, N-03**: Scroll threshold raised to 30px with an intermediate glass state (`backdrop-blur-md bg-white/70`).
- **N-04, N-05**: Animated hamburger bars to an X via Framer Motion, with proper `aria-expanded` attributes.
- **N-06**: Focus trap, Escape key handler, and focus restoration implemented on the mobile overlay.
- **N-07**: Nav link `focus-visible` ring inversion on the hero section.
- **N-08**: IntersectionObserver-driven active-section underline indicator.
- **N-02**: Confirmed Home link omission per PRD.