### PR TITLE
phase-4

### DIFF
--- a/Plan/QA-PLAN.md
+++ b/Plan/QA-PLAN.md
@@ -109,7 +109,7 @@ Phase 1 is broken into **7 GitHub issues** (vertical slices). Items in the same 
 - IntersectionObserver-driven active-section underline indicator (N-08) **(pulled forward, P2)**.
 - Confirm "Home" link omission per PRD; document deviation in code comment if asked (N-02).
 
-### Phase 3 — Hero (`components/Hero.tsx`)
+### Phase 3 — Hero (`components/Hero.tsx`) ✅ Done
 
 - **Bug:** `h-screen` → `min-h-[100svh]` (H-01).
 - Migrate background `<div style backgroundImage>` → `<Image fill priority sizes="100vw" />` with overlay sibling (H-02, H-08).

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,6 +13,7 @@ const inter = Inter({
   variable: "--font-inter",
   subsets: ["latin"],
   weight: ["300", "400", "500"],
+  style: ["normal", "italic"],
 });
 
 const siteUrl = "https://trappedactor.com";

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -25,11 +25,11 @@ export default function About() {
             </p>
           </div>
           <div className="mt-4">
-            <p className="text-lg">
+            <p className="text-lg flex items-baseline gap-2">
               <em>Much love,</em>
-            </p>
-            <p className="font-playfair text-7xl font-semibold mt-1 text-[#222222]">
-              S
+              <span className="font-playfair text-3xl font-semibold italic text-[#222222]">
+                S
+              </span>
             </p>
           </div>
         </div>

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -5,7 +5,7 @@ export default function About() {
     <section id="about" className="py-24 px-8 md:px-16 bg-white">
       <h2 className="sr-only">About</h2>
       <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
-        <div className="relative w-full aspect-[3/4]">
+        <div className="relative w-full aspect-[3/4] shadow-[0_8px_30px_rgba(0,0,0,0.08)] ring-1 ring-[#e8e0d4]">
           <Image
             src={`${process.env.NEXT_PUBLIC_BASE_PATH}/images/about.jpg`}
             alt="Smaran Harihar"

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 export default function About() {
   return (
     <section id="about" className="py-24 px-8 md:px-16 bg-white">
+      <h2 className="sr-only">About</h2>
       <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
         <div className="relative w-full aspect-[3/4]">
           <Image

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -8,7 +8,7 @@ export default function About() {
         <div className="relative w-full aspect-[3/4] shadow-[0_8px_30px_rgba(0,0,0,0.08)] ring-1 ring-[#e8e0d4]">
           <Image
             src={`${process.env.NEXT_PUBLIC_BASE_PATH}/images/about.jpg`}
-            alt="Smaran Harihar"
+            alt="Smaran Harihar — portrait, looking off camera, soft natural light"
             fill
             className="object-cover"
           />

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -1,10 +1,11 @@
 import Image from "next/image";
+import FadeInOnScroll from "./FadeInOnScroll";
 
 export default function About() {
   return (
     <section id="about" className="py-24 px-8 md:px-16 bg-white">
       <h2 className="sr-only">About</h2>
-      <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
+      <FadeInOnScroll className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
         <div className="relative w-full aspect-[3/4] shadow-[0_8px_30px_rgba(0,0,0,0.08)] ring-1 ring-[#e8e0d4]">
           <Image
             src={`${process.env.NEXT_PUBLIC_BASE_PATH}/images/about.jpg`}
@@ -33,7 +34,7 @@ export default function About() {
             </p>
           </div>
         </div>
-      </div>
+      </FadeInOnScroll>
     </section>
   );
 }

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -14,14 +14,16 @@ export default function About() {
           />
         </div>
         <div className="flex flex-col gap-6 text-[#222222]">
-          <p className="text-lg leading-relaxed">
-            I am an immigrant to the USA.
-          </p>
-          <p className="text-lg leading-relaxed">
-            Opportunities are all around and so are obstacles. Always try to
-            make the most of what you got and hope for the Best. That is my
-            life&apos;s motto.
-          </p>
+          <div className="max-w-prose flex flex-col gap-6">
+            <p className="text-lg leading-relaxed">
+              I am an immigrant to the USA.
+            </p>
+            <p className="text-lg leading-relaxed">
+              Opportunities are all around and so are obstacles. Always try to
+              make the most of what you got and hope for the Best. That is my
+              life&apos;s motto.
+            </p>
+          </div>
           <div className="mt-4">
             <p className="text-lg">
               <em>Much love,</em>

--- a/tests/About.test.tsx
+++ b/tests/About.test.tsx
@@ -20,6 +20,15 @@ describe("About", () => {
     expect(document.querySelector("#about")).toBeInTheDocument();
   });
 
+  it("renders a visually-hidden h2 About as the first child of the section", () => {
+    render(<About />);
+    const section = document.querySelector("#about") as HTMLElement;
+    const firstChild = section.firstElementChild as HTMLElement;
+    expect(firstChild.tagName).toBe("H2");
+    expect(firstChild).toHaveTextContent("About");
+    expect(firstChild.className).toMatch(/sr-only/);
+  });
+
   it("renders the about image", () => {
     render(<About />);
     const img = screen.getByAltText("Smaran Harihar");

--- a/tests/About.test.tsx
+++ b/tests/About.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import About from "../components/About";
 
 vi.mock("next/image", () => ({
@@ -118,5 +120,16 @@ describe("About", () => {
     const section = document.querySelector("#about");
     const grid = section?.querySelector(".md\\:grid-cols-2");
     expect(grid).toBeInTheDocument();
+  });
+
+  it("Inter font config in app/layout.tsx includes italic style for Much love", () => {
+    const layoutSource = readFileSync(
+      join(process.cwd(), "app", "layout.tsx"),
+      "utf8"
+    );
+    const interBlockMatch = layoutSource.match(/Inter\(\{[\s\S]*?\}\)/);
+    expect(interBlockMatch).not.toBeNull();
+    const interBlock = interBlockMatch?.[0] ?? "";
+    expect(interBlock).toMatch(/style:\s*\[[^\]]*["']italic["'][^\]]*\]/);
   });
 });

--- a/tests/About.test.tsx
+++ b/tests/About.test.tsx
@@ -60,6 +60,33 @@ describe("About", () => {
     ).toBeInTheDocument();
   });
 
+  it("constrains body paragraphs by max-w-prose, but not the signature block", () => {
+    render(<About />);
+    const firstPara = screen.getByText("I am an immigrant to the USA.");
+    let node: HTMLElement | null = firstPara.parentElement;
+    let foundProseAncestor = false;
+    while (node) {
+      if (/max-w-prose/.test(node.className)) {
+        foundProseAncestor = true;
+        break;
+      }
+      node = node.parentElement;
+    }
+    expect(foundProseAncestor).toBe(true);
+
+    const muchLove = screen.getByText("Much love,");
+    let signatureNode: HTMLElement | null = muchLove.parentElement;
+    let signatureInsideProse = false;
+    while (signatureNode) {
+      if (/max-w-prose/.test(signatureNode.className)) {
+        signatureInsideProse = true;
+        break;
+      }
+      signatureNode = signatureNode.parentElement;
+    }
+    expect(signatureInsideProse).toBe(false);
+  });
+
   it("renders Much love in italic", () => {
     render(<About />);
     const muchLove = screen.getByText("Much love,");

--- a/tests/About.test.tsx
+++ b/tests/About.test.tsx
@@ -29,16 +29,18 @@ describe("About", () => {
     expect(firstChild.className).toMatch(/sr-only/);
   });
 
-  it("renders the about image", () => {
+  it("renders the about image with descriptive alt text", () => {
     render(<About />);
-    const img = screen.getByAltText("Smaran Harihar");
+    const img = screen.getByAltText(/Smaran/);
     expect(img).toBeInTheDocument();
     expect(img.getAttribute("src")).toContain("about.jpg");
+    const alt = img.getAttribute("alt") ?? "";
+    expect(alt.length).toBeGreaterThan(20);
   });
 
   it("portrait wrapper has shadow, warm border, and preserved aspect ratio", () => {
     render(<About />);
-    const img = screen.getByAltText("Smaran Harihar");
+    const img = screen.getByAltText(/Smaran/);
     const wrapper = img.parentElement as HTMLElement;
     expect(wrapper.className).toMatch(/shadow-/);
     expect(wrapper.className).toMatch(/ring-1|border\b/);

--- a/tests/About.test.tsx
+++ b/tests/About.test.tsx
@@ -36,6 +36,16 @@ describe("About", () => {
     expect(img.getAttribute("src")).toContain("about.jpg");
   });
 
+  it("portrait wrapper has shadow, warm border, and preserved aspect ratio", () => {
+    render(<About />);
+    const img = screen.getByAltText("Smaran Harihar");
+    const wrapper = img.parentElement as HTMLElement;
+    expect(wrapper.className).toMatch(/shadow-/);
+    expect(wrapper.className).toMatch(/ring-1|border\b/);
+    expect(wrapper.className).toMatch(/ring-\[#e8e0d4\]|border-\[#e8e0d4\]/);
+    expect(wrapper.className).toMatch(/aspect-\[3\/4\]/);
+  });
+
   it("renders the first bio paragraph", () => {
     render(<About />);
     expect(

--- a/tests/About.test.tsx
+++ b/tests/About.test.tsx
@@ -95,11 +95,22 @@ describe("About", () => {
     expect(muchLove.tagName).toBe("EM");
   });
 
-  it("renders the decorative S signature", () => {
+  it("renders Much love and S inline within a shared parent", () => {
     render(<About />);
-    expect(screen.getByText("S")).toBeInTheDocument();
+    const muchLove = screen.getByText("Much love,");
     const s = screen.getByText("S");
-    expect(s.className).toMatch(/text-/);
+    const sharedParent = muchLove.closest("p");
+    expect(sharedParent).not.toBeNull();
+    expect(sharedParent?.contains(s)).toBe(true);
+  });
+
+  it("renders the decorative S as Playfair italic and not as a text-7xl block", () => {
+    render(<About />);
+    const s = screen.getByText("S");
+    expect(s.className).toMatch(/font-playfair/);
+    expect(s.className).toMatch(/italic/);
+    expect(s.className).not.toMatch(/text-7xl/);
+    expect(s.className).not.toMatch(/\bmt-1\b/);
   });
 
   it("has a two-column layout class", () => {

--- a/tests/About.test.tsx
+++ b/tests/About.test.tsx
@@ -16,6 +16,33 @@ vi.mock("next/image", () => ({
   }) => <img src={src} alt={alt} {...props} />,
 }));
 
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      className,
+      initial,
+      whileInView,
+      viewport,
+      transition,
+      ...props
+    }: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any) => (
+      <div
+        className={className}
+        data-initial={JSON.stringify(initial)}
+        data-whileinview={JSON.stringify(whileInView)}
+        data-viewport={JSON.stringify(viewport)}
+        data-transition={JSON.stringify(transition)}
+        {...props}
+      >
+        {children}
+      </div>
+    ),
+  },
+  useReducedMotion: vi.fn(() => false),
+}));
+
 describe("About", () => {
   it("renders a section with id about", () => {
     render(<About />);
@@ -120,6 +147,22 @@ describe("About", () => {
     const section = document.querySelector("#about");
     const grid = section?.querySelector(".md\\:grid-cols-2");
     expect(grid).toBeInTheDocument();
+  });
+
+  it("wraps the inner grid in FadeInOnScroll, but not the section itself", () => {
+    render(<About />);
+    const section = document.querySelector("#about") as HTMLElement;
+    const heading = screen.getByRole("heading", { level: 2 });
+    const img = screen.getByAltText(/Smaran/);
+
+    const headingFadeAncestor = heading.closest("div[data-whileinview]");
+    const imgFadeAncestor = img.closest("div[data-whileinview]");
+
+    expect(headingFadeAncestor || imgFadeAncestor).not.toBeNull();
+    const fade = (imgFadeAncestor ?? headingFadeAncestor) as HTMLElement;
+    expect(fade.getAttribute("data-whileinview")).toContain('"opacity":1');
+
+    expect(section.getAttribute("data-whileinview")).toBeNull();
   });
 
   it("Inter font config in app/layout.tsx includes italic style for Much love", () => {


### PR DESCRIPTION
## Summary

Phase 4 — polish the About section per `Plan/Phase-4.md`. One sub-PR per slice (4.1–4.7), each closing its corresponding issue (#57–#63).

## Slices

- 4.1 — Visually-hidden h2 (#57)
- 4.2 — Image shadow + warm border (#58)
- 4.3 — `max-w-prose` constraint (#59)
- 4.4 — Inline decorative S (#60)
- 4.5 — Inter italic verification (#61, depends on 4.4)
- 4.6 — Descriptive alt text (#62)
- 4.7 — Entrance fade (#63, depends on 4.1 + 4.4)

## Test plan

- [ ] All sub-PRs pass `lint`, `typecheck`, `test`
- [ ] Manual: VoiceOver reads "About, heading level 2" entering the section
- [ ] Manual: portrait shows soft shadow + warm hairline border
- [ ] Manual: paragraphs wrap ~70ch on 1920px viewport
- [ ] Manual: "Much love," renders italic; "S" inline beside it
- [ ] Manual: scrolling into About fades content in once