### PR TITLE
feat(about): add visually-hidden h2 (4.1)

### DIFF
--- a/components/About.tsx
+++ b/components/About.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 export default function About() {
   return (
     <section id="about" className="py-24 px-8 md:px-16 bg-white">
+      <h2 className="sr-only">About</h2>
       <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
         <div className="relative w-full aspect-[3/4]">
           <Image

--- a/tests/About.test.tsx
+++ b/tests/About.test.tsx
@@ -20,6 +20,15 @@ describe("About", () => {
     expect(document.querySelector("#about")).toBeInTheDocument();
   });
 
+  it("renders a visually-hidden h2 About as the first child of the section", () => {
+    render(<About />);
+    const section = document.querySelector("#about") as HTMLElement;
+    const firstChild = section.firstElementChild as HTMLElement;
+    expect(firstChild.tagName).toBe("H2");
+    expect(firstChild).toHaveTextContent("About");
+    expect(firstChild.className).toMatch(/sr-only/);
+  });
+
   it("renders the about image", () => {
     render(<About />);
     const img = screen.getByAltText("Smaran Harihar");


### PR DESCRIPTION
## Summary

- Adds `<h2 className="sr-only">About</h2>` as the first child of `<section id="about">`.
- Section now has a heading for SEO crawlers and assistive tech.

Closes #57

## Test plan

- [x] `npm run lint && npm run typecheck && npm run test` pass
- [ ] Manual: VoiceOver/NVDA reads "About, heading level 2" entering the section