### PR TITLE
feat(about): polish portrait with shadow + warm border (4.2)

### DIFF
--- a/components/About.tsx
+++ b/components/About.tsx
@@ -5,7 +5,7 @@ export default function About() {
     <section id="about" className="py-24 px-8 md:px-16 bg-white">
       <h2 className="sr-only">About</h2>
       <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
-        <div className="relative w-full aspect-[3/4]">
+        <div className="relative w-full aspect-[3/4] shadow-[0_8px_30px_rgba(0,0,0,0.08)] ring-1 ring-[#e8e0d4]">
           <Image
             src={`${process.env.NEXT_PUBLIC_BASE_PATH}/images/about.jpg`}
             alt="Smaran Harihar"

--- a/tests/About.test.tsx
+++ b/tests/About.test.tsx
@@ -36,6 +36,16 @@ describe("About", () => {
     expect(img.getAttribute("src")).toContain("about.jpg");
   });
 
+  it("portrait wrapper has shadow, warm border, and preserved aspect ratio", () => {
+    render(<About />);
+    const img = screen.getByAltText("Smaran Harihar");
+    const wrapper = img.parentElement as HTMLElement;
+    expect(wrapper.className).toMatch(/shadow-/);
+    expect(wrapper.className).toMatch(/ring-1|border\b/);
+    expect(wrapper.className).toMatch(/ring-\[#e8e0d4\]|border-\[#e8e0d4\]/);
+    expect(wrapper.className).toMatch(/aspect-\[3\/4\]/);
+  });
+
   it("renders the first bio paragraph", () => {
     render(<About />);
     expect(


### PR DESCRIPTION
## Summary

- Adds `shadow-[0_8px_30px_rgba(0,0,0,0.08)]` and `ring-1 ring-[#e8e0d4]` to the portrait wrapper.
- `aspect-[3/4]` and `object-cover` preserved.

Closes #58

## Test plan

- [x] `npm run lint && npm run typecheck && npm run test` pass
- [ ] Manual: portrait shows soft shadow + warm hairline border, no harsh edge