### PR TITLE
feat(about): constrain paragraphs to max-w-prose (4.3)

### DIFF
--- a/components/About.tsx
+++ b/components/About.tsx
@@ -14,14 +14,16 @@ export default function About() {
           />
         </div>
         <div className="flex flex-col gap-6 text-[#222222]">
-          <p className="text-lg leading-relaxed">
-            I am an immigrant to the USA.
-          </p>
-          <p className="text-lg leading-relaxed">
-            Opportunities are all around and so are obstacles. Always try to
-            make the most of what you got and hope for the Best. That is my
-            life&apos;s motto.
-          </p>
+          <div className="max-w-prose flex flex-col gap-6">
+            <p className="text-lg leading-relaxed">
+              I am an immigrant to the USA.
+            </p>
+            <p className="text-lg leading-relaxed">
+              Opportunities are all around and so are obstacles. Always try to
+              make the most of what you got and hope for the Best. That is my
+              life&apos;s motto.
+            </p>
+          </div>
           <div className="mt-4">
             <p className="text-lg">
               <em>Much love,</em>

--- a/tests/About.test.tsx
+++ b/tests/About.test.tsx
@@ -60,6 +60,33 @@ describe("About", () => {
     ).toBeInTheDocument();
   });
 
+  it("constrains body paragraphs by max-w-prose, but not the signature block", () => {
+    render(<About />);
+    const firstPara = screen.getByText("I am an immigrant to the USA.");
+    let node: HTMLElement | null = firstPara.parentElement;
+    let foundProseAncestor = false;
+    while (node) {
+      if (/max-w-prose/.test(node.className)) {
+        foundProseAncestor = true;
+        break;
+      }
+      node = node.parentElement;
+    }
+    expect(foundProseAncestor).toBe(true);
+
+    const muchLove = screen.getByText("Much love,");
+    let signatureNode: HTMLElement | null = muchLove.parentElement;
+    let signatureInsideProse = false;
+    while (signatureNode) {
+      if (/max-w-prose/.test(signatureNode.className)) {
+        signatureInsideProse = true;
+        break;
+      }
+      signatureNode = signatureNode.parentElement;
+    }
+    expect(signatureInsideProse).toBe(false);
+  });
+
   it("renders Much love in italic", () => {
     render(<About />);
     const muchLove = screen.getByText("Much love,");


### PR DESCRIPTION
## Summary

- Wraps the two body paragraphs in a `max-w-prose flex flex-col gap-6` div.
- Signature block stays outside the constrained wrapper.

Closes #59

## Test plan

- [x] `npm run lint && npm run typecheck && npm run test` pass
- [ ] Manual: on 1920px viewport, body paragraphs wrap at ~70ch