### PR TITLE
feat(about): descriptive alt text for portrait (4.6)

### DIFF
--- a/components/About.tsx
+++ b/components/About.tsx
@@ -8,7 +8,7 @@ export default function About() {
         <div className="relative w-full aspect-[3/4] shadow-[0_8px_30px_rgba(0,0,0,0.08)] ring-1 ring-[#e8e0d4]">
           <Image
             src={`${process.env.NEXT_PUBLIC_BASE_PATH}/images/about.jpg`}
-            alt="Smaran Harihar"
+            alt="Smaran Harihar — portrait, looking off camera, soft natural light"
             fill
             className="object-cover"
           />

--- a/tests/About.test.tsx
+++ b/tests/About.test.tsx
@@ -29,16 +29,18 @@ describe("About", () => {
     expect(firstChild.className).toMatch(/sr-only/);
   });
 
-  it("renders the about image", () => {
+  it("renders the about image with descriptive alt text", () => {
     render(<About />);
-    const img = screen.getByAltText("Smaran Harihar");
+    const img = screen.getByAltText(/Smaran/);
     expect(img).toBeInTheDocument();
     expect(img.getAttribute("src")).toContain("about.jpg");
+    const alt = img.getAttribute("alt") ?? "";
+    expect(alt.length).toBeGreaterThan(20);
   });
 
   it("portrait wrapper has shadow, warm border, and preserved aspect ratio", () => {
     render(<About />);
-    const img = screen.getByAltText("Smaran Harihar");
+    const img = screen.getByAltText(/Smaran/);
     const wrapper = img.parentElement as HTMLElement;
     expect(wrapper.className).toMatch(/shadow-/);
     expect(wrapper.className).toMatch(/ring-1|border\b/);


### PR DESCRIPTION
## Summary

- Replaces the generic `alt="Smaran Harihar"` with a descriptive alt: `"Smaran Harihar — portrait, looking off camera, soft natural light"`.
- Test asserts `alt.length > 20` and contains "Smaran" rather than pinning the exact string, so the user can revise without breaking tests.

Closes #62

## Notes

Alt copy is a placeholder — feel free to revise to better match the actual image.

## Test plan

- [x] `npm run lint && npm run typecheck && npm run test` pass
- [ ] Manual: hover the portrait → screen reader announces the descriptive alt