### PR TITLE
feat(about): inline decorative S beside Much love (4.4)

### DIFF
--- a/components/About.tsx
+++ b/components/About.tsx
@@ -25,11 +25,11 @@ export default function About() {
             </p>
           </div>
           <div className="mt-4">
-            <p className="text-lg">
+            <p className="text-lg flex items-baseline gap-2">
               <em>Much love,</em>
-            </p>
-            <p className="font-playfair text-7xl font-semibold mt-1 text-[#222222]">
-              S
+              <span className="font-playfair text-3xl font-semibold italic text-[#222222]">
+                S
+              </span>
             </p>
           </div>
         </div>

--- a/tests/About.test.tsx
+++ b/tests/About.test.tsx
@@ -95,11 +95,22 @@ describe("About", () => {
     expect(muchLove.tagName).toBe("EM");
   });
 
-  it("renders the decorative S signature", () => {
+  it("renders Much love and S inline within a shared parent", () => {
     render(<About />);
-    expect(screen.getByText("S")).toBeInTheDocument();
+    const muchLove = screen.getByText("Much love,");
     const s = screen.getByText("S");
-    expect(s.className).toMatch(/text-/);
+    const sharedParent = muchLove.closest("p");
+    expect(sharedParent).not.toBeNull();
+    expect(sharedParent?.contains(s)).toBe(true);
+  });
+
+  it("renders the decorative S as Playfair italic and not as a text-7xl block", () => {
+    render(<About />);
+    const s = screen.getByText("S");
+    expect(s.className).toMatch(/font-playfair/);
+    expect(s.className).toMatch(/italic/);
+    expect(s.className).not.toMatch(/text-7xl/);
+    expect(s.className).not.toMatch(/\bmt-1\b/);
   });
 
   it("has a two-column layout class", () => {


### PR DESCRIPTION
## Summary

- Collapses the signature into a single line: "Much love," + Playfair italic "S".
- "S" is now `text-3xl font-playfair italic`, no longer a `text-7xl` block.
- Used Option A (inline) per plan default. Option B (enlarged watermark) remains a future tweak.

Closes #60

## Test plan

- [x] `npm run lint && npm run typecheck && npm run test` pass
- [ ] Manual: signature line reads as a handwritten flourish, not orphaned