### PR TITLE
feat(layout): include Inter italic for About signature (4.5)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,6 +13,7 @@ const inter = Inter({
   variable: "--font-inter",
   subsets: ["latin"],
   weight: ["300", "400", "500"],
+  style: ["normal", "italic"],
 });
 
 const siteUrl = "https://trappedactor.com";

--- a/tests/About.test.tsx
+++ b/tests/About.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import About from "../components/About";
 
 vi.mock("next/image", () => ({
@@ -118,5 +120,16 @@ describe("About", () => {
     const section = document.querySelector("#about");
     const grid = section?.querySelector(".md\\:grid-cols-2");
     expect(grid).toBeInTheDocument();
+  });
+
+  it("Inter font config in app/layout.tsx includes italic style for Much love", () => {
+    const layoutSource = readFileSync(
+      join(process.cwd(), "app", "layout.tsx"),
+      "utf8"
+    );
+    const interBlockMatch = layoutSource.match(/Inter\(\{[\s\S]*?\}\)/);
+    expect(interBlockMatch).not.toBeNull();
+    const interBlock = interBlockMatch?.[0] ?? "";
+    expect(interBlock).toMatch(/style:\s*\[[^\]]*["']italic["'][^\]]*\]/);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `style: ["normal", "italic"]` to the Inter font config in `app/layout.tsx` so `<em>Much love,</em>` renders with real italic glyphs (not synthetic-slanted upright glyphs).
- New static-source test asserts the italic style is in the Inter config, so a future regression that drops italic will fail loudly.

**Decision**: chose to extend Inter rather than swap to Playfair italic, because italic is broadly useful for emphasis site-wide.

Closes #61

## Test plan

- [x] `npm run lint && npm run typecheck && npm run test` pass
- [ ] Manual: "Much love," renders italic in Chrome and Safari, with proper italic glyphs (notice the lowercase a/e/g shapes)