### PR TITLE
feat(about): fade in section contents on scroll (4.7)

### DIFF
--- a/components/About.tsx
+++ b/components/About.tsx
@@ -1,10 +1,11 @@
 import Image from "next/image";
+import FadeInOnScroll from "./FadeInOnScroll";
 
 export default function About() {
   return (
     <section id="about" className="py-24 px-8 md:px-16 bg-white">
       <h2 className="sr-only">About</h2>
-      <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
+      <FadeInOnScroll className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
         <div className="relative w-full aspect-[3/4] shadow-[0_8px_30px_rgba(0,0,0,0.08)] ring-1 ring-[#e8e0d4]">
           <Image
             src={`${process.env.NEXT_PUBLIC_BASE_PATH}/images/about.jpg`}
@@ -33,7 +34,7 @@ export default function About() {
             </p>
           </div>
         </div>
-      </div>
+      </FadeInOnScroll>
     </section>
   );
 }

--- a/tests/About.test.tsx
+++ b/tests/About.test.tsx
@@ -16,6 +16,33 @@ vi.mock("next/image", () => ({
   }) => <img src={src} alt={alt} {...props} />,
 }));
 
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      className,
+      initial,
+      whileInView,
+      viewport,
+      transition,
+      ...props
+    }: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any) => (
+      <div
+        className={className}
+        data-initial={JSON.stringify(initial)}
+        data-whileinview={JSON.stringify(whileInView)}
+        data-viewport={JSON.stringify(viewport)}
+        data-transition={JSON.stringify(transition)}
+        {...props}
+      >
+        {children}
+      </div>
+    ),
+  },
+  useReducedMotion: vi.fn(() => false),
+}));
+
 describe("About", () => {
   it("renders a section with id about", () => {
     render(<About />);
@@ -120,6 +147,22 @@ describe("About", () => {
     const section = document.querySelector("#about");
     const grid = section?.querySelector(".md\\:grid-cols-2");
     expect(grid).toBeInTheDocument();
+  });
+
+  it("wraps the inner grid in FadeInOnScroll, but not the section itself", () => {
+    render(<About />);
+    const section = document.querySelector("#about") as HTMLElement;
+    const heading = screen.getByRole("heading", { level: 2 });
+    const img = screen.getByAltText(/Smaran/);
+
+    const headingFadeAncestor = heading.closest("div[data-whileinview]");
+    const imgFadeAncestor = img.closest("div[data-whileinview]");
+
+    expect(headingFadeAncestor || imgFadeAncestor).not.toBeNull();
+    const fade = (imgFadeAncestor ?? headingFadeAncestor) as HTMLElement;
+    expect(fade.getAttribute("data-whileinview")).toContain('"opacity":1');
+
+    expect(section.getAttribute("data-whileinview")).toBeNull();
   });
 
   it("Inter font config in app/layout.tsx includes italic style for Much love", () => {


### PR DESCRIPTION
## Summary

- Wraps the About inner grid in `<FadeInOnScroll>` so its contents fade up once when scrolled into view.
- The `<section>` element itself is unchanged so the white background remains continuous with surrounding sections.

Closes #63

## Test plan

- [x] `npm run lint && npm run typecheck && npm run test` pass (152 / 152)
- [ ] Manual: scroll the About section into view → contents fade up once, no flicker
- [ ] Manual: with reduced motion, contents render immediately