### PR TITLE
5.1 — Drop dates from tile data (D7)

### DIFF
--- a/components/ReelsPreview.tsx
+++ b/components/ReelsPreview.tsx
@@ -3,10 +3,10 @@
 import { useEffect, useState } from "react";
 
 const videos = [
-  { id: "utchWkrauZg", title: "First Responders Part 1", date: "4/21/24" },
-  { id: "Kg4OPd4saVE", title: "First Responders Part 2", date: "4/21/24" },
-  { id: "p_ZpjegmmJc", title: "Being Charlie", date: "4/21/24" },
-  { id: "ol3Y_YYAjcw", title: "Slate Shot LA", date: "4/21/24" },
+  { id: "utchWkrauZg", title: "First Responders Part 1" },
+  { id: "Kg4OPd4saVE", title: "First Responders Part 2" },
+  { id: "p_ZpjegmmJc", title: "Being Charlie" },
+  { id: "ol3Y_YYAjcw", title: "Slate Shot LA" },
 ];
 
 export default function ReelsPreview() {
@@ -54,7 +54,6 @@ export default function ReelsPreview() {
               </div>
               <div className="mt-3">
                 <p className="text-[#222222] font-medium">{v.title}</p>
-                <p className="text-sm text-gray-500 mt-0.5">{v.date}</p>
               </div>
             </button>
           ))}

--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -23,6 +23,12 @@ describe("ReelsPreview — tiles", () => {
     expect(screen.getByText("Slate Shot LA")).toBeInTheDocument();
   });
 
+  it("does not render fabricated dates on any tile", () => {
+    render(<ReelsPreview />);
+    const reels = document.querySelector("#reels")!;
+    expect(reels.textContent).not.toContain("4/21/24");
+  });
+
   it("renders a thumbnail for each video", () => {
     render(<ReelsPreview />);
     const thumbnails = screen.getAllByRole("img");


### PR DESCRIPTION
Closes #72

Removes the fabricated `4/21/24` dates from the Reels tile data. Drops the date field from the `videos` array and removes the date paragraph from the tile JSX.

**Tests:** added assertion that no tile renders the date string.

Made with [Cursor](https://cursor.com)