### PR TITLE
phase-5: Reels polish, bug fixes, and accessibility

### DIFF
--- a/components/ReelsPreview.tsx
+++ b/components/ReelsPreview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import Image from "next/image";
+import { useEffect, useRef, useState } from "react";
 
 const videos = [
   { id: "utchWkrauZg", title: "First Responders Part 1" },
@@ -9,8 +10,65 @@ const videos = [
   { id: "ol3Y_YYAjcw", title: "Slate Shot LA" },
 ];
 
+type Video = (typeof videos)[number];
+
+function ReelTile({
+  video,
+  onPlay,
+}: {
+  video: Video;
+  onPlay: (id: string, btn: HTMLButtonElement) => void;
+}) {
+  const [thumbSrc, setThumbSrc] = useState(
+    `https://i.ytimg.com/vi/${video.id}/maxresdefault.jpg`
+  );
+
+  return (
+    <button
+      aria-label={`Play ${video.title}`}
+      className="group relative w-full text-left focus:outline-none"
+      onClick={(e) => onPlay(video.id, e.currentTarget)}
+    >
+      <div className="relative overflow-hidden aspect-video bg-black">
+        <Image
+          src={thumbSrc}
+          alt={video.title}
+          fill
+          sizes="(max-width: 640px) 100vw, 50vw"
+          className="object-cover group-hover:scale-[1.02] transition-transform duration-300"
+          onError={() =>
+            setThumbSrc(`https://i.ytimg.com/vi/${video.id}/hqdefault.jpg`)
+          }
+        />
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="w-14 h-14 rounded-full bg-white/80 flex items-center justify-center transition-all duration-200 group-hover:scale-110 group-hover:bg-white group-hover:ring-2 group-hover:ring-white/40">
+            <svg
+              aria-hidden="true"
+              className="w-6 h-6 text-[#222222] ml-1"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path d="M8 5v14l11-7z" />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div className="mt-3">
+        <p className="text-[#222222] font-medium">{video.title}</p>
+      </div>
+    </button>
+  );
+}
+
 export default function ReelsPreview() {
   const [activeId, setActiveId] = useState<string | null>(null);
+  const lastTileRef = useRef<HTMLButtonElement | null>(null);
+  const closeRef = useRef<HTMLButtonElement | null>(null);
+
+  const open = (id: string, btn: HTMLButtonElement) => {
+    lastTileRef.current = btn;
+    setActiveId(id);
+  };
 
   useEffect(() => {
     if (!activeId) return;
@@ -30,6 +88,16 @@ export default function ReelsPreview() {
     };
   }, [activeId]);
 
+  useEffect(() => {
+    if (activeId) {
+      closeRef.current?.focus();
+    } else if (lastTileRef.current) {
+      lastTileRef.current.focus();
+    }
+  }, [activeId]);
+
+  const activeVideo = activeId ? videos.find((v) => v.id === activeId) : null;
+
   return (
     <section id="reels" className="py-24 px-8 md:px-16 bg-white">
       <div className="max-w-6xl mx-auto">
@@ -41,75 +109,45 @@ export default function ReelsPreview() {
         </h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
           {videos.map((v) => (
-            <button
-              key={v.id}
-              aria-label={`Play ${v.title}`}
-              className="group relative w-full text-left focus:outline-none"
-              onClick={() => setActiveId(v.id)}
-            >
-              <div className="relative overflow-hidden aspect-video bg-black">
-                <img
-                  src={`https://i.ytimg.com/vi/${v.id}/hqdefault.jpg`}
-                  alt={v.title}
-                  className="w-full h-full object-cover group-hover:opacity-80 transition-opacity"
-                />
-                <div className="absolute inset-0 flex items-center justify-center">
-                  <div className="w-14 h-14 rounded-full bg-white/80 flex items-center justify-center group-hover:bg-white transition-colors">
-                    <svg
-                      aria-hidden="true"
-                      className="w-6 h-6 text-[#222222] ml-1"
-                      fill="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path d="M8 5v14l11-7z" />
-                    </svg>
-                  </div>
-                </div>
-              </div>
-              <div className="mt-3">
-                <p className="text-[#222222] font-medium">{v.title}</p>
-              </div>
-            </button>
+            <ReelTile key={v.id} video={v} onPlay={open} />
           ))}
         </div>
       </div>
 
-      {activeId &&
-        (() => {
-          const activeVideo = videos.find((v) => v.id === activeId);
-          return (
-            <div
-              role="dialog"
-              aria-modal="true"
-              className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4"
-              onClick={() => setActiveId(null)}
-            >
-              <button
-                type="button"
-                aria-label="Close video"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setActiveId(null);
-                }}
-                className="absolute top-4 right-4 z-10 w-10 h-10 rounded-full bg-white/90 hover:bg-white text-[#222222] flex items-center justify-center text-xl"
-              >
-                ×
-              </button>
-              <div
-                className="w-full max-w-4xl aspect-video"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <iframe
-                  src={`https://www.youtube.com/embed/${activeId}?autoplay=1`}
-                  title={`${activeVideo?.title} (YouTube video)`}
-                  className="w-full h-full"
-                  allow="autoplay; encrypted-media"
-                  allowFullScreen
-                />
-              </div>
-            </div>
-          );
-        })()}
+      {activeId && activeVideo && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label={`${activeVideo.title} video player`}
+          className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4"
+          onClick={() => setActiveId(null)}
+        >
+          <button
+            ref={closeRef}
+            type="button"
+            aria-label="Close video"
+            onClick={(e) => {
+              e.stopPropagation();
+              setActiveId(null);
+            }}
+            className="absolute top-4 right-4 z-10 w-10 h-10 rounded-full bg-white/90 hover:bg-white text-[#222222] flex items-center justify-center text-xl"
+          >
+            ×
+          </button>
+          <div
+            className="w-full max-w-4xl aspect-video"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <iframe
+              src={`https://www.youtube-nocookie.com/embed/${activeId}?autoplay=1`}
+              title={`${activeVideo.title} (YouTube video)`}
+              className="w-full h-full"
+              allow="autoplay; encrypted-media"
+              allowFullScreen
+            />
+          </div>
+        </div>
+      )}
     </section>
   );
 }

--- a/components/ReelsPreview.tsx
+++ b/components/ReelsPreview.tsx
@@ -84,6 +84,17 @@ export default function ReelsPreview() {
               className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4"
               onClick={() => setActiveId(null)}
             >
+              <button
+                type="button"
+                aria-label="Close video"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setActiveId(null);
+                }}
+                className="absolute top-4 right-4 z-10 w-10 h-10 rounded-full bg-white/90 hover:bg-white text-[#222222] flex items-center justify-center text-xl"
+              >
+                ×
+              </button>
               <div
                 className="w-full max-w-4xl aspect-video"
                 onClick={(e) => e.stopPropagation()}

--- a/components/ReelsPreview.tsx
+++ b/components/ReelsPreview.tsx
@@ -60,26 +60,31 @@ export default function ReelsPreview() {
         </div>
       </div>
 
-      {activeId && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4"
-          onClick={() => setActiveId(null)}
-        >
-          <div
-            className="w-full max-w-4xl aspect-video"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <iframe
-              src={`https://www.youtube.com/embed/${activeId}?autoplay=1`}
-              className="w-full h-full"
-              allow="autoplay; encrypted-media"
-              allowFullScreen
-            />
-          </div>
-        </div>
-      )}
+      {activeId &&
+        (() => {
+          const activeVideo = videos.find((v) => v.id === activeId);
+          return (
+            <div
+              role="dialog"
+              aria-modal="true"
+              className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4"
+              onClick={() => setActiveId(null)}
+            >
+              <div
+                className="w-full max-w-4xl aspect-video"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <iframe
+                  src={`https://www.youtube.com/embed/${activeId}?autoplay=1`}
+                  title={`${activeVideo?.title} (YouTube video)`}
+                  className="w-full h-full"
+                  allow="autoplay; encrypted-media"
+                  allowFullScreen
+                />
+              </div>
+            </div>
+          );
+        })()}
     </section>
   );
 }

--- a/components/ReelsPreview.tsx
+++ b/components/ReelsPreview.tsx
@@ -21,6 +21,15 @@ export default function ReelsPreview() {
     return () => window.removeEventListener("keydown", onKey);
   }, [activeId]);
 
+  useEffect(() => {
+    if (!activeId) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [activeId]);
+
   return (
     <section id="reels" className="py-24 px-8 md:px-16 bg-white">
       <div className="max-w-6xl mx-auto">

--- a/components/ReelsPreview.tsx
+++ b/components/ReelsPreview.tsx
@@ -33,6 +33,9 @@ export default function ReelsPreview() {
   return (
     <section id="reels" className="py-24 px-8 md:px-16 bg-white">
       <div className="max-w-6xl mx-auto">
+        <p className="text-xs md:text-sm tracking-[0.2em] uppercase font-medium text-gray-500 mb-3">
+          Selected Work
+        </p>
         <h2 className="font-playfair text-4xl font-semibold text-[#222222] mb-12">
           Reels
         </h2>

--- a/components/ReelsPreview.tsx
+++ b/components/ReelsPreview.tsx
@@ -40,6 +40,7 @@ export default function ReelsPreview() {
           {videos.map((v) => (
             <button
               key={v.id}
+              aria-label={`Play ${v.title}`}
               className="group relative w-full text-left focus:outline-none"
               onClick={() => setActiveId(v.id)}
             >
@@ -52,6 +53,7 @@ export default function ReelsPreview() {
                 <div className="absolute inset-0 flex items-center justify-center">
                   <div className="w-14 h-14 rounded-full bg-white/80 flex items-center justify-center group-hover:bg-white transition-colors">
                     <svg
+                      aria-hidden="true"
                       className="w-6 h-6 text-[#222222] ml-1"
                       fill="currentColor"
                       viewBox="0 0 24 24"

--- a/components/ReelsPreview.tsx
+++ b/components/ReelsPreview.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
+import FadeInOnScroll from "./FadeInOnScroll";
 
 const videos = [
   { id: "utchWkrauZg", title: "First Responders Part 1" },
@@ -100,19 +101,21 @@ export default function ReelsPreview() {
 
   return (
     <section id="reels" className="py-24 px-8 md:px-16 bg-white">
-      <div className="max-w-6xl mx-auto">
-        <p className="text-xs md:text-sm tracking-[0.2em] uppercase font-medium text-gray-500 mb-3">
-          Selected Work
-        </p>
-        <h2 className="font-playfair text-4xl font-semibold text-[#222222] mb-12">
-          Reels
-        </h2>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-          {videos.map((v) => (
-            <ReelTile key={v.id} video={v} onPlay={open} />
-          ))}
+      <FadeInOnScroll>
+        <div className="max-w-6xl mx-auto">
+          <p className="text-xs md:text-sm tracking-[0.2em] uppercase font-medium text-gray-500 mb-3">
+            Selected Work
+          </p>
+          <h2 className="font-playfair text-4xl font-semibold text-[#222222] mb-12">
+            Reels
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+            {videos.map((v) => (
+              <ReelTile key={v.id} video={v} onPlay={open} />
+            ))}
+          </div>
         </div>
-      </div>
+      </FadeInOnScroll>
 
       {activeId && activeVideo && (
         <div

--- a/components/ReelsPreview.tsx
+++ b/components/ReelsPreview.tsx
@@ -3,10 +3,10 @@
 import { useEffect, useState } from "react";
 
 const videos = [
-  { id: "utchWkrauZg", title: "First Responders Part 1", date: "4/21/24" },
-  { id: "Kg4OPd4saVE", title: "First Responders Part 2", date: "4/21/24" },
-  { id: "p_ZpjegmmJc", title: "Being Charlie", date: "4/21/24" },
-  { id: "ol3Y_YYAjcw", title: "Slate Shot LA", date: "4/21/24" },
+  { id: "utchWkrauZg", title: "First Responders Part 1" },
+  { id: "Kg4OPd4saVE", title: "First Responders Part 2" },
+  { id: "p_ZpjegmmJc", title: "Being Charlie" },
+  { id: "ol3Y_YYAjcw", title: "Slate Shot LA" },
 ];
 
 export default function ReelsPreview() {
@@ -54,7 +54,6 @@ export default function ReelsPreview() {
               </div>
               <div className="mt-3">
                 <p className="text-[#222222] font-medium">{v.title}</p>
-                <p className="text-sm text-gray-500 mt-0.5">{v.date}</p>
               </div>
             </button>
           ))}

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,7 +9,10 @@ const nextConfig: NextConfig = {
     basePath,
     assetPrefix: basePath,
   }),
-  images: { unoptimized: true },
+  images: {
+    unoptimized: true,
+    remotePatterns: [{ protocol: "https", hostname: "i.ytimg.com" }],
+  },
   env: {
     NEXT_PUBLIC_BASE_PATH: basePath,
   },

--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -23,6 +23,12 @@ describe("ReelsPreview — tiles", () => {
     expect(screen.getByText("Slate Shot LA")).toBeInTheDocument();
   });
 
+  it("does not render fabricated dates on any tile", () => {
+    render(<ReelsPreview />);
+    const reels = document.querySelector("#reels")!;
+    expect(reels.textContent).not.toContain("4/21/24");
+  });
+
   it("renders a thumbnail for each video", () => {
     render(<ReelsPreview />);
     const thumbnails = screen.getAllByRole("img");

--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -92,4 +92,22 @@ describe("ReelsPreview — modal", () => {
     fireEvent.click(screen.getByRole("dialog"));
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
+
+  it("iframe has a non-empty title attribute when modal is open", () => {
+    render(<ReelsPreview />);
+    fireEvent.click(
+      screen.getByText("First Responders Part 1").closest("button")!
+    );
+    const iframe = document.querySelector("iframe");
+    expect(iframe?.title.length).toBeGreaterThan(0);
+  });
+
+  it("iframe title includes the video title", () => {
+    render(<ReelsPreview />);
+    fireEvent.click(
+      screen.getByText("First Responders Part 1").closest("button")!
+    );
+    const iframe = document.querySelector("iframe");
+    expect(iframe?.title).toContain("First Responders Part 1");
+  });
 });

--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -231,6 +231,32 @@ describe("ReelsPreview — modal", () => {
   });
 });
 
+describe("ReelsPreview — modal focus and aria", () => {
+  it("dialog has aria-label containing the video title", () => {
+    render(<ReelsPreview />);
+    fireEvent.click(screen.getByText("Being Charlie").closest("button")!);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.getAttribute("aria-label")).toContain("Being Charlie");
+  });
+
+  it("focus moves to the close button when modal opens", () => {
+    render(<ReelsPreview />);
+    fireEvent.click(screen.getByText("Being Charlie").closest("button")!);
+    const closeBtn = screen.getByRole("button", { name: /close video/i });
+    expect(document.activeElement).toBe(closeBtn);
+  });
+
+  it("focus returns to the tile that opened the modal after Escape", () => {
+    render(<ReelsPreview />);
+    const tileBtn = screen.getByRole("button", {
+      name: /play being charlie/i,
+    });
+    fireEvent.click(tileBtn);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(document.activeElement).toBe(tileBtn);
+  });
+});
+
 describe("ReelsPreview — close button", () => {
   it("close button renders when modal is open", () => {
     render(<ReelsPreview />);

--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -41,6 +41,37 @@ describe("ReelsPreview — tiles", () => {
     const buttons = screen.getAllByRole("button");
     expect(buttons.length).toBe(4);
   });
+
+  it("play SVG has aria-hidden=true", () => {
+    render(<ReelsPreview />);
+    const svgs = document.querySelectorAll("svg");
+    expect(svgs.length).toBeGreaterThan(0);
+    svgs.forEach((svg) => {
+      expect(svg.getAttribute("aria-hidden")).toBe("true");
+    });
+  });
+
+  it("tile buttons have descriptive aria-label", () => {
+    render(<ReelsPreview />);
+    expect(
+      screen.getByRole("button", { name: /play first responders part 1/i })
+    ).toBeInTheDocument();
+  });
+
+  it("each tile button aria-label includes the video title", () => {
+    render(<ReelsPreview />);
+    const videoTitles = [
+      "First Responders Part 1",
+      "First Responders Part 2",
+      "Being Charlie",
+      "Slate Shot LA",
+    ];
+    videoTitles.forEach((title) => {
+      expect(
+        screen.getByRole("button", { name: new RegExp(`play ${title}`, "i") })
+      ).toBeInTheDocument();
+    });
+  });
 });
 
 describe("ReelsPreview — modal", () => {

--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -152,6 +152,24 @@ describe("ReelsPreview — modal", () => {
     expect(iframe?.getAttribute("src")).toContain("autoplay=1");
   });
 
+  it("iframe src uses youtube-nocookie.com", () => {
+    render(<ReelsPreview />);
+    fireEvent.click(screen.getByText("Being Charlie").closest("button")!);
+    const iframe = document.querySelector("iframe");
+    expect(iframe?.getAttribute("src")).toMatch(
+      /^https:\/\/www\.youtube-nocookie\.com\/embed\//
+    );
+  });
+
+  it("iframe src still includes the video id", () => {
+    render(<ReelsPreview />);
+    fireEvent.click(
+      screen.getByText("First Responders Part 1").closest("button")!
+    );
+    const iframe = document.querySelector("iframe");
+    expect(iframe?.getAttribute("src")).toContain("utchWkrauZg");
+  });
+
   it("closes modal on Escape key", () => {
     render(<ReelsPreview />);
     fireEvent.click(screen.getByText("Being Charlie").closest("button")!);

--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -12,6 +12,18 @@ describe("ReelsPreview — section", () => {
     render(<ReelsPreview />);
     expect(screen.getByRole("heading", { name: "Reels" })).toBeInTheDocument();
   });
+
+  it("renders the Selected Work eyebrow above the heading", () => {
+    render(<ReelsPreview />);
+    expect(screen.getByText(/selected work/i)).toBeInTheDocument();
+  });
+
+  it("eyebrow has uppercase and tracking classes", () => {
+    render(<ReelsPreview />);
+    const eyebrow = screen.getByText(/selected work/i);
+    expect(eyebrow.className).toMatch(/uppercase/);
+    expect(eyebrow.className).toMatch(/tracking-/);
+  });
 });
 
 describe("ReelsPreview — tiles", () => {

--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -114,6 +114,34 @@ describe("ReelsPreview — tiles", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("play button circle has hover scale class", () => {
+    render(<ReelsPreview />);
+    const playCircle = document
+      .querySelector("button[aria-label^='Play']")!
+      .querySelector("div.rounded-full")!;
+    expect(playCircle.className).toMatch(/group-hover:scale-/);
+  });
+
+  it("play button circle has hover ring class", () => {
+    render(<ReelsPreview />);
+    const playCircle = document
+      .querySelector("button[aria-label^='Play']")!
+      .querySelector("div.rounded-full")!;
+    expect(playCircle.className).toMatch(/group-hover:ring-/);
+  });
+
+  it("thumbnail Image has hover scale class", () => {
+    render(<ReelsPreview />);
+    const thumbnail = screen.getAllByRole("img")[0];
+    expect(thumbnail.className).toMatch(/group-hover:scale-/);
+  });
+
+  it("thumbnail Image has transition class", () => {
+    render(<ReelsPreview />);
+    const thumbnail = screen.getAllByRole("img")[0];
+    expect(thumbnail.className).toMatch(/transition-/);
+  });
 });
 
 describe("ReelsPreview — modal", () => {

--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -111,3 +111,25 @@ describe("ReelsPreview — modal", () => {
     expect(iframe?.title).toContain("First Responders Part 1");
   });
 });
+
+describe("ReelsPreview — scroll lock", () => {
+  it("sets body overflow hidden when modal opens", () => {
+    render(<ReelsPreview />);
+    fireEvent.click(screen.getByText("Being Charlie").closest("button")!);
+    expect(document.body.style.overflow).toBe("hidden");
+  });
+
+  it("restores body overflow when modal closes", () => {
+    render(<ReelsPreview />);
+    fireEvent.click(screen.getByText("Being Charlie").closest("button")!);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("restores body overflow on unmount", () => {
+    const { unmount } = render(<ReelsPreview />);
+    fireEvent.click(screen.getByText("Being Charlie").closest("button")!);
+    unmount();
+    expect(document.body.style.overflow).toBe("");
+  });
+});

--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -1,6 +1,18 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import ReelsPreview from "../components/ReelsPreview";
+
+vi.mock("next/image", () => ({
+  default: ({
+    src,
+    alt,
+    ...props
+  }: {
+    src: string;
+    alt: string;
+    [key: string]: unknown;
+  }) => <img src={src} alt={alt} {...props} />,
+}));
 
 describe("ReelsPreview — section", () => {
   it("renders a section with id reels", () => {
@@ -46,6 +58,24 @@ describe("ReelsPreview — tiles", () => {
     const thumbnails = screen.getAllByRole("img");
     expect(thumbnails.length).toBeGreaterThanOrEqual(4);
     expect(thumbnails[0].getAttribute("src")).toContain("ytimg.com");
+  });
+
+  it("thumbnails use maxresdefault as default src", () => {
+    render(<ReelsPreview />);
+    const thumbnails = screen.getAllByRole("img");
+    expect(thumbnails[0].getAttribute("src")).toContain("maxresdefault.jpg");
+  });
+
+  it("thumbnail alt matches the video title", () => {
+    render(<ReelsPreview />);
+    expect(screen.getByAltText("First Responders Part 1")).toBeInTheDocument();
+    expect(screen.getByAltText("Being Charlie")).toBeInTheDocument();
+  });
+
+  it("thumbnails use Next.js Image component (sizes prop present)", () => {
+    render(<ReelsPreview />);
+    const thumbnails = screen.getAllByRole("img");
+    expect(thumbnails[0]).toHaveAttribute("sizes");
   });
 
   it("renders 4 play buttons", () => {

--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -155,6 +155,38 @@ describe("ReelsPreview — modal", () => {
   });
 });
 
+describe("ReelsPreview — close button", () => {
+  it("close button renders when modal is open", () => {
+    render(<ReelsPreview />);
+    fireEvent.click(screen.getByText("Being Charlie").closest("button")!);
+    expect(
+      screen.getByRole("button", { name: /close video/i })
+    ).toBeInTheDocument();
+  });
+
+  it("close button is not in the DOM when modal is closed", () => {
+    render(<ReelsPreview />);
+    expect(
+      screen.queryByRole("button", { name: /close video/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("clicking close button dismisses the modal", () => {
+    render(<ReelsPreview />);
+    fireEvent.click(screen.getByText("Being Charlie").closest("button")!);
+    fireEvent.click(screen.getByRole("button", { name: /close video/i }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("close button has aria-label Close video", () => {
+    render(<ReelsPreview />);
+    fireEvent.click(screen.getByText("Being Charlie").closest("button")!);
+    expect(
+      screen.getByRole("button", { name: /close video/i })
+    ).toHaveAttribute("aria-label", "Close video");
+  });
+});
+
 describe("ReelsPreview — scroll lock", () => {
   it("sets body overflow hidden when modal opens", () => {
     render(<ReelsPreview />);

--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -14,6 +14,33 @@ vi.mock("next/image", () => ({
   }) => <img src={src} alt={alt} {...props} />,
 }));
 
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      className,
+      initial,
+      whileInView,
+      viewport,
+      transition,
+      ...props
+    }: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any) => (
+      <div
+        className={className}
+        data-initial={JSON.stringify(initial)}
+        data-whileinview={JSON.stringify(whileInView)}
+        data-viewport={JSON.stringify(viewport)}
+        data-transition={JSON.stringify(transition)}
+        {...props}
+      >
+        {children}
+      </div>
+    ),
+  },
+  useReducedMotion: () => false,
+}));
+
 describe("ReelsPreview — section", () => {
   it("renders a section with id reels", () => {
     render(<ReelsPreview />);
@@ -35,6 +62,16 @@ describe("ReelsPreview — section", () => {
     const eyebrow = screen.getByText(/selected work/i);
     expect(eyebrow.className).toMatch(/uppercase/);
     expect(eyebrow.className).toMatch(/tracking-/);
+  });
+
+  it("inner content is wrapped in FadeInOnScroll", () => {
+    render(<ReelsPreview />);
+    const heading = screen.getByRole("heading", { name: "Reels" });
+    const fadeAncestor = heading.closest("div[data-whileinview]");
+    expect(fadeAncestor).not.toBeNull();
+    expect(fadeAncestor!.getAttribute("data-whileinview")).toContain(
+      '"opacity":1'
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes all QA-PLAN bugs and adds polish to the Reels section (`components/ReelsPreview.tsx`).

**QA IDs addressed:** R-01, R-02, R-03, R-04, R-05, R-06, R-07, R-10, R-11, R-12, P-05, G-01, D7

## Issues

- #72 — 5.1: Drop dates from tile data (D7)
- #73 — 5.2: Add title attribute to iframe (R-01)
- #74 — 5.4: Body scroll lock while modal is open (R-03)
- #75 — 5.7: Play button + SVG accessibility (R-10)
- #76 — 5.10: Add Selected Work eyebrow (R-12)
- #77 — 5.3: Visible close button on modal (R-02)
- #78 — 5.5: Migrate thumbnails to Image + remotePatterns (R-04, R-05)
- #79 — 5.9: Switch embed to youtube-nocookie.com (P-05)
- #80 — 5.6: Hover ring + thumbnail zoom polish (R-06, R-07)
- #81 — 5.8: Modal aria-label + focus management (R-11)
- #82 — 5.11: Entrance fade via FadeInOnScroll (G-01)

Made with [Cursor](https://cursor.com)