### PR TITLE
5.2 — Add title attribute to iframe (R-01)

### DIFF
--- a/components/ReelsPreview.tsx
+++ b/components/ReelsPreview.tsx
@@ -60,26 +60,31 @@ export default function ReelsPreview() {
         </div>
       </div>
 
-      {activeId && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4"
-          onClick={() => setActiveId(null)}
-        >
-          <div
-            className="w-full max-w-4xl aspect-video"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <iframe
-              src={`https://www.youtube.com/embed/${activeId}?autoplay=1`}
-              className="w-full h-full"
-              allow="autoplay; encrypted-media"
-              allowFullScreen
-            />
-          </div>
-        </div>
-      )}
+      {activeId &&
+        (() => {
+          const activeVideo = videos.find((v) => v.id === activeId);
+          return (
+            <div
+              role="dialog"
+              aria-modal="true"
+              className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4"
+              onClick={() => setActiveId(null)}
+            >
+              <div
+                className="w-full max-w-4xl aspect-video"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <iframe
+                  src={`https://www.youtube.com/embed/${activeId}?autoplay=1`}
+                  title={`${activeVideo?.title} (YouTube video)`}
+                  className="w-full h-full"
+                  allow="autoplay; encrypted-media"
+                  allowFullScreen
+                />
+              </div>
+            </div>
+          );
+        })()}
     </section>
   );
 }

--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -92,4 +92,22 @@ describe("ReelsPreview — modal", () => {
     fireEvent.click(screen.getByRole("dialog"));
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
+
+  it("iframe has a non-empty title attribute when modal is open", () => {
+    render(<ReelsPreview />);
+    fireEvent.click(
+      screen.getByText("First Responders Part 1").closest("button")!
+    );
+    const iframe = document.querySelector("iframe");
+    expect(iframe?.title.length).toBeGreaterThan(0);
+  });
+
+  it("iframe title includes the video title", () => {
+    render(<ReelsPreview />);
+    fireEvent.click(
+      screen.getByText("First Responders Part 1").closest("button")!
+    );
+    const iframe = document.querySelector("iframe");
+    expect(iframe?.title).toContain("First Responders Part 1");
+  });
 });


### PR DESCRIPTION
Closes #73

Adds a `title` attribute to the YouTube iframe so screen readers know what it contains. Finds the active video object via `videos.find()` at render time.

Made with [Cursor](https://cursor.com)