### PR TITLE
5.4 — Body scroll lock while modal is open (R-03)

### DIFF
--- a/components/ReelsPreview.tsx
+++ b/components/ReelsPreview.tsx
@@ -21,6 +21,15 @@ export default function ReelsPreview() {
     return () => window.removeEventListener("keydown", onKey);
   }, [activeId]);
 
+  useEffect(() => {
+    if (!activeId) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [activeId]);
+
   return (
     <section id="reels" className="py-24 px-8 md:px-16 bg-white">
       <div className="max-w-6xl mx-auto">

--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -111,3 +111,25 @@ describe("ReelsPreview — modal", () => {
     expect(iframe?.title).toContain("First Responders Part 1");
   });
 });
+
+describe("ReelsPreview — scroll lock", () => {
+  it("sets body overflow hidden when modal opens", () => {
+    render(<ReelsPreview />);
+    fireEvent.click(screen.getByText("Being Charlie").closest("button")!);
+    expect(document.body.style.overflow).toBe("hidden");
+  });
+
+  it("restores body overflow when modal closes", () => {
+    render(<ReelsPreview />);
+    fireEvent.click(screen.getByText("Being Charlie").closest("button")!);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("restores body overflow on unmount", () => {
+    const { unmount } = render(<ReelsPreview />);
+    fireEvent.click(screen.getByText("Being Charlie").closest("button")!);
+    unmount();
+    expect(document.body.style.overflow).toBe("");
+  });
+});


### PR DESCRIPTION
Closes #74

Adds `useEffect` to set `document.body.style.overflow = 'hidden'` when the modal opens and restores it on close/unmount.

Made with [Cursor](https://cursor.com)