### PR TITLE
5.7 — Play button + SVG accessibility (R-10)

### DIFF
--- a/components/ReelsPreview.tsx
+++ b/components/ReelsPreview.tsx
@@ -40,6 +40,7 @@ export default function ReelsPreview() {
           {videos.map((v) => (
             <button
               key={v.id}
+              aria-label={`Play ${v.title}`}
               className="group relative w-full text-left focus:outline-none"
               onClick={() => setActiveId(v.id)}
             >
@@ -52,6 +53,7 @@ export default function ReelsPreview() {
                 <div className="absolute inset-0 flex items-center justify-center">
                   <div className="w-14 h-14 rounded-full bg-white/80 flex items-center justify-center group-hover:bg-white transition-colors">
                     <svg
+                      aria-hidden="true"
                       className="w-6 h-6 text-[#222222] ml-1"
                       fill="currentColor"
                       viewBox="0 0 24 24"

--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -41,6 +41,37 @@ describe("ReelsPreview — tiles", () => {
     const buttons = screen.getAllByRole("button");
     expect(buttons.length).toBe(4);
   });
+
+  it("play SVG has aria-hidden=true", () => {
+    render(<ReelsPreview />);
+    const svgs = document.querySelectorAll("svg");
+    expect(svgs.length).toBeGreaterThan(0);
+    svgs.forEach((svg) => {
+      expect(svg.getAttribute("aria-hidden")).toBe("true");
+    });
+  });
+
+  it("tile buttons have descriptive aria-label", () => {
+    render(<ReelsPreview />);
+    expect(
+      screen.getByRole("button", { name: /play first responders part 1/i })
+    ).toBeInTheDocument();
+  });
+
+  it("each tile button aria-label includes the video title", () => {
+    render(<ReelsPreview />);
+    const videoTitles = [
+      "First Responders Part 1",
+      "First Responders Part 2",
+      "Being Charlie",
+      "Slate Shot LA",
+    ];
+    videoTitles.forEach((title) => {
+      expect(
+        screen.getByRole("button", { name: new RegExp(`play ${title}`, "i") })
+      ).toBeInTheDocument();
+    });
+  });
 });
 
 describe("ReelsPreview — modal", () => {


### PR DESCRIPTION
Closes #75

Adds `aria-hidden="true"` to the decorative play SVG and `aria-label="Play {title}"` to each tile button for clear screen reader accessible names.

Made with [Cursor](https://cursor.com)