### PR TITLE
5.10 — Add 'Selected Work' eyebrow above Reels heading (R-12)

### DIFF
--- a/components/ReelsPreview.tsx
+++ b/components/ReelsPreview.tsx
@@ -33,6 +33,9 @@ export default function ReelsPreview() {
   return (
     <section id="reels" className="py-24 px-8 md:px-16 bg-white">
       <div className="max-w-6xl mx-auto">
+        <p className="text-xs md:text-sm tracking-[0.2em] uppercase font-medium text-gray-500 mb-3">
+          Selected Work
+        </p>
         <h2 className="font-playfair text-4xl font-semibold text-[#222222] mb-12">
           Reels
         </h2>

--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -12,6 +12,18 @@ describe("ReelsPreview — section", () => {
     render(<ReelsPreview />);
     expect(screen.getByRole("heading", { name: "Reels" })).toBeInTheDocument();
   });
+
+  it("renders the Selected Work eyebrow above the heading", () => {
+    render(<ReelsPreview />);
+    expect(screen.getByText(/selected work/i)).toBeInTheDocument();
+  });
+
+  it("eyebrow has uppercase and tracking classes", () => {
+    render(<ReelsPreview />);
+    const eyebrow = screen.getByText(/selected work/i);
+    expect(eyebrow.className).toMatch(/uppercase/);
+    expect(eyebrow.className).toMatch(/tracking-/);
+  });
 });
 
 describe("ReelsPreview — tiles", () => {


### PR DESCRIPTION
Closes #76

Adds an uppercase tracking eyebrow 'Selected Work' above the Reels h2, mirroring the typographic pattern from the live site.

Made with [Cursor](https://cursor.com)