### PR TITLE
5.3 — Visible close button on modal (R-02)

### DIFF
--- a/components/ReelsPreview.tsx
+++ b/components/ReelsPreview.tsx
@@ -84,6 +84,17 @@ export default function ReelsPreview() {
               className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4"
               onClick={() => setActiveId(null)}
             >
+              <button
+                type="button"
+                aria-label="Close video"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setActiveId(null);
+                }}
+                className="absolute top-4 right-4 z-10 w-10 h-10 rounded-full bg-white/90 hover:bg-white text-[#222222] flex items-center justify-center text-xl"
+              >
+                ×
+              </button>
               <div
                 className="w-full max-w-4xl aspect-video"
                 onClick={(e) => e.stopPropagation()}

--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -155,6 +155,38 @@ describe("ReelsPreview — modal", () => {
   });
 });
 
+describe("ReelsPreview — close button", () => {
+  it("close button renders when modal is open", () => {
+    render(<ReelsPreview />);
+    fireEvent.click(screen.getByText("Being Charlie").closest("button")!);
+    expect(
+      screen.getByRole("button", { name: /close video/i })
+    ).toBeInTheDocument();
+  });
+
+  it("close button is not in the DOM when modal is closed", () => {
+    render(<ReelsPreview />);
+    expect(
+      screen.queryByRole("button", { name: /close video/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("clicking close button dismisses the modal", () => {
+    render(<ReelsPreview />);
+    fireEvent.click(screen.getByText("Being Charlie").closest("button")!);
+    fireEvent.click(screen.getByRole("button", { name: /close video/i }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("close button has aria-label Close video", () => {
+    render(<ReelsPreview />);
+    fireEvent.click(screen.getByText("Being Charlie").closest("button")!);
+    expect(
+      screen.getByRole("button", { name: /close video/i })
+    ).toHaveAttribute("aria-label", "Close video");
+  });
+});
+
 describe("ReelsPreview — scroll lock", () => {
   it("sets body overflow hidden when modal opens", () => {
     render(<ReelsPreview />);


### PR DESCRIPTION
Closes #77

Adds a visible × close button (absolute top-right) inside the modal dialog. Works alongside the existing Escape key and backdrop-click handlers.

Made with [Cursor](https://cursor.com)