### PR TITLE
5.6 — Polish play button: hover ring + thumbnail zoom (R-06, R-07)

### DIFF
--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -114,6 +114,34 @@ describe("ReelsPreview — tiles", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("play button circle has hover scale class", () => {
+    render(<ReelsPreview />);
+    const playCircle = document
+      .querySelector("button[aria-label^='Play']")!
+      .querySelector("div.rounded-full")!;
+    expect(playCircle.className).toMatch(/group-hover:scale-/);
+  });
+
+  it("play button circle has hover ring class", () => {
+    render(<ReelsPreview />);
+    const playCircle = document
+      .querySelector("button[aria-label^='Play']")!
+      .querySelector("div.rounded-full")!;
+    expect(playCircle.className).toMatch(/group-hover:ring-/);
+  });
+
+  it("thumbnail Image has hover scale class", () => {
+    render(<ReelsPreview />);
+    const thumbnail = screen.getAllByRole("img")[0];
+    expect(thumbnail.className).toMatch(/group-hover:scale-/);
+  });
+
+  it("thumbnail Image has transition class", () => {
+    render(<ReelsPreview />);
+    const thumbnail = screen.getAllByRole("img")[0];
+    expect(thumbnail.className).toMatch(/transition-/);
+  });
 });
 
 describe("ReelsPreview — modal", () => {


### PR DESCRIPTION
Closes #80

Tests cover the hover scale/ring on the play button and zoom on the thumbnail. Implementation in the 5.5 rewrite: `group-hover:scale-110 group-hover:ring-2 group-hover:ring-white/40` on the play circle and `group-hover:scale-[1.02]` on the thumbnail.

Made with [Cursor](https://cursor.com)