### PR TITLE
5.8 — Modal aria-label + focus management (R-11)

### DIFF
--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -231,6 +231,32 @@ describe("ReelsPreview — modal", () => {
   });
 });
 
+describe("ReelsPreview — modal focus and aria", () => {
+  it("dialog has aria-label containing the video title", () => {
+    render(<ReelsPreview />);
+    fireEvent.click(screen.getByText("Being Charlie").closest("button")!);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.getAttribute("aria-label")).toContain("Being Charlie");
+  });
+
+  it("focus moves to the close button when modal opens", () => {
+    render(<ReelsPreview />);
+    fireEvent.click(screen.getByText("Being Charlie").closest("button")!);
+    const closeBtn = screen.getByRole("button", { name: /close video/i });
+    expect(document.activeElement).toBe(closeBtn);
+  });
+
+  it("focus returns to the tile that opened the modal after Escape", () => {
+    render(<ReelsPreview />);
+    const tileBtn = screen.getByRole("button", {
+      name: /play being charlie/i,
+    });
+    fireEvent.click(tileBtn);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(document.activeElement).toBe(tileBtn);
+  });
+});
+
 describe("ReelsPreview — close button", () => {
   it("close button renders when modal is open", () => {
     render(<ReelsPreview />);


### PR DESCRIPTION
Closes #81

Tests cover: dialog `aria-label` with video title, focus trap to close button on open, and focus restoration to originating tile on close. Implementation landed in the 5.5 rewrite via `closeRef`, `lastTileRef`, and `open()` helper.

Made with [Cursor](https://cursor.com)