### PR TITLE
5.11 — Entrance fade via FadeInOnScroll (G-01)

### DIFF
--- a/components/ReelsPreview.tsx
+++ b/components/ReelsPreview.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
+import FadeInOnScroll from "./FadeInOnScroll";
 
 const videos = [
   { id: "utchWkrauZg", title: "First Responders Part 1" },
@@ -100,19 +101,21 @@ export default function ReelsPreview() {
 
   return (
     <section id="reels" className="py-24 px-8 md:px-16 bg-white">
-      <div className="max-w-6xl mx-auto">
-        <p className="text-xs md:text-sm tracking-[0.2em] uppercase font-medium text-gray-500 mb-3">
-          Selected Work
-        </p>
-        <h2 className="font-playfair text-4xl font-semibold text-[#222222] mb-12">
-          Reels
-        </h2>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-          {videos.map((v) => (
-            <ReelTile key={v.id} video={v} onPlay={open} />
-          ))}
+      <FadeInOnScroll>
+        <div className="max-w-6xl mx-auto">
+          <p className="text-xs md:text-sm tracking-[0.2em] uppercase font-medium text-gray-500 mb-3">
+            Selected Work
+          </p>
+          <h2 className="font-playfair text-4xl font-semibold text-[#222222] mb-12">
+            Reels
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+            {videos.map((v) => (
+              <ReelTile key={v.id} video={v} onPlay={open} />
+            ))}
+          </div>
         </div>
-      </div>
+      </FadeInOnScroll>
 
       {activeId && activeVideo && (
         <div

--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -14,6 +14,33 @@ vi.mock("next/image", () => ({
   }) => <img src={src} alt={alt} {...props} />,
 }));
 
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      className,
+      initial,
+      whileInView,
+      viewport,
+      transition,
+      ...props
+    }: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any) => (
+      <div
+        className={className}
+        data-initial={JSON.stringify(initial)}
+        data-whileinview={JSON.stringify(whileInView)}
+        data-viewport={JSON.stringify(viewport)}
+        data-transition={JSON.stringify(transition)}
+        {...props}
+      >
+        {children}
+      </div>
+    ),
+  },
+  useReducedMotion: () => false,
+}));
+
 describe("ReelsPreview — section", () => {
   it("renders a section with id reels", () => {
     render(<ReelsPreview />);
@@ -35,6 +62,16 @@ describe("ReelsPreview — section", () => {
     const eyebrow = screen.getByText(/selected work/i);
     expect(eyebrow.className).toMatch(/uppercase/);
     expect(eyebrow.className).toMatch(/tracking-/);
+  });
+
+  it("inner content is wrapped in FadeInOnScroll", () => {
+    render(<ReelsPreview />);
+    const heading = screen.getByRole("heading", { name: "Reels" });
+    const fadeAncestor = heading.closest("div[data-whileinview]");
+    expect(fadeAncestor).not.toBeNull();
+    expect(fadeAncestor!.getAttribute("data-whileinview")).toContain(
+      '"opacity":1'
+    );
   });
 });
 


### PR DESCRIPTION
Closes #82

Wraps the inner `max-w-6xl` div in `<FadeInOnScroll>` so the grid + heading fade in as the Reels section scrolls into view.

Made with [Cursor](https://cursor.com)