### PR TITLE
phase-6: Headshots carousel polish

### DIFF
--- a/Plan/QA-PLAN.md
+++ b/Plan/QA-PLAN.md
@@ -119,7 +119,7 @@ Phase 1 is broken into **7 GitHub issues** (vertical slices). Items in the same 
 - Apostrophes → real Unicode (H-07).
 - Compress `hero.jpg` (currently 550KB → target ~180KB AVIF/WebP via build-time `sharp` script in `scripts/optimize-images.ts`) (P-01).
 
-### Phase 4 — About (`components/About.tsx`)
+### Phase 4 — About (`components/About.tsx`) ✅ Done
 
 - Visually-hidden `<h2>About</h2>` for nav/SEO (A-01).
 - Image polish: subtle drop shadow + 1px warm border (A-02).

--- a/components/Headshots.tsx
+++ b/components/Headshots.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import Image from "next/image";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import FadeInOnScroll from "./FadeInOnScroll";
 
 const headshots = [
   { src: "/images/headshot-1.jpg", alt: "Headshot 1" },
@@ -38,83 +39,85 @@ export default function Headshots() {
 
   return (
     <section id="headshots" className="py-24 px-8 md:px-16 bg-white">
-      <div className="max-w-6xl mx-auto">
-        <h2 className="font-playfair text-4xl font-semibold text-[#222222] mb-12">
-          Headshots
-        </h2>
-        <div className="relative flex items-center justify-center gap-4">
-          <button
-            aria-label="Previous headshot"
-            onClick={prev}
-            className="flex-shrink-0 w-12 h-12 rounded-full border border-[#222222] flex items-center justify-center hover:bg-[#222222] hover:text-white hover:-translate-y-0.5 transition-all"
+      <FadeInOnScroll>
+        <div className="max-w-6xl mx-auto">
+          <h2 className="font-playfair text-4xl font-semibold text-[#222222] mb-12">
+            Headshots
+          </h2>
+          <div className="relative flex items-center justify-center gap-4">
+            <button
+              aria-label="Previous headshot"
+              onClick={prev}
+              className="flex-shrink-0 w-12 h-12 rounded-full border border-[#222222] flex items-center justify-center hover:bg-[#222222] hover:text-white hover:-translate-y-0.5 transition-all"
+            >
+              <svg
+                aria-hidden="true"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <polyline points="15 18 9 12 15 6" />
+              </svg>
+            </button>
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={index}
+                initial={{ opacity: reduce ? 1 : 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: reduce ? 1 : 0 }}
+                transition={{ duration: reduce ? 0 : 0.3 }}
+                className="relative w-full max-w-2xl aspect-[3/4]"
+              >
+                <Image
+                  src={`${base}${headshots[index].src}`}
+                  alt={headshots[index].alt}
+                  fill
+                  sizes="(max-width: 1024px) 100vw, 672px"
+                  className="object-cover"
+                  priority={index === 0}
+                />
+              </motion.div>
+            </AnimatePresence>
+            <button
+              aria-label="Next headshot"
+              onClick={next}
+              className="flex-shrink-0 w-12 h-12 rounded-full border border-[#222222] flex items-center justify-center hover:bg-[#222222] hover:text-white hover:-translate-y-0.5 transition-all"
+            >
+              <svg
+                aria-hidden="true"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <polyline points="9 18 15 12 9 6" />
+              </svg>
+            </button>
+          </div>
+          <p
+            aria-live="polite"
+            aria-atomic="true"
+            className="text-center font-playfair text-2xl text-[#222222] mt-4"
           >
-            <svg
-              aria-hidden="true"
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <polyline points="15 18 9 12 15 6" />
-            </svg>
-          </button>
-          <AnimatePresence mode="wait">
-            <motion.div
-              key={index}
-              initial={{ opacity: reduce ? 1 : 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: reduce ? 1 : 0 }}
-              transition={{ duration: reduce ? 0 : 0.3 }}
-              className="relative w-full max-w-2xl aspect-[3/4]"
-            >
-              <Image
-                src={`${base}${headshots[index].src}`}
-                alt={headshots[index].alt}
-                fill
-                sizes="(max-width: 1024px) 100vw, 672px"
-                className="object-cover"
-                priority={index === 0}
-              />
-            </motion.div>
-          </AnimatePresence>
-          <button
-            aria-label="Next headshot"
-            onClick={next}
-            className="flex-shrink-0 w-12 h-12 rounded-full border border-[#222222] flex items-center justify-center hover:bg-[#222222] hover:text-white hover:-translate-y-0.5 transition-all"
-          >
-            <svg
-              aria-hidden="true"
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <polyline points="9 18 15 12 9 6" />
-            </svg>
-          </button>
+            <span className="sr-only">
+              Image {index + 1} of {headshots.length}
+            </span>
+            <span aria-hidden="true">
+              {String(index + 1).padStart(2, "0")} &mdash;{" "}
+              {String(headshots.length).padStart(2, "0")}
+            </span>
+          </p>
         </div>
-        <p
-          aria-live="polite"
-          aria-atomic="true"
-          className="text-center font-playfair text-2xl text-[#222222] mt-4"
-        >
-          <span className="sr-only">
-            Image {index + 1} of {headshots.length}
-          </span>
-          <span aria-hidden="true">
-            {String(index + 1).padStart(2, "0")} &mdash;{" "}
-            {String(headshots.length).padStart(2, "0")}
-          </span>
-        </p>
-      </div>
+      </FadeInOnScroll>
     </section>
   );
 }

--- a/components/Headshots.tsx
+++ b/components/Headshots.tsx
@@ -38,7 +38,7 @@ export default function Headshots() {
               alt={headshots[index].alt}
               fill
               className="object-cover"
-              priority
+              priority={index === 0}
             />
           </div>
           <button

--- a/components/Headshots.tsx
+++ b/components/Headshots.tsx
@@ -65,8 +65,18 @@ export default function Headshots() {
             &#8594;
           </button>
         </div>
-        <p className="text-center text-sm text-gray-400 mt-4">
-          {index + 1} / {headshots.length}
+        <p
+          aria-live="polite"
+          aria-atomic="true"
+          className="text-center font-playfair text-2xl text-[#222222] mt-4"
+        >
+          <span className="sr-only">
+            Image {index + 1} of {headshots.length}
+          </span>
+          <span aria-hidden="true">
+            {String(index + 1).padStart(2, "0")} &mdash;{" "}
+            {String(headshots.length).padStart(2, "0")}
+          </span>
         </p>
       </div>
     </section>

--- a/components/Headshots.tsx
+++ b/components/Headshots.tsx
@@ -46,9 +46,21 @@ export default function Headshots() {
           <button
             aria-label="Previous headshot"
             onClick={prev}
-            className="flex-shrink-0 w-10 h-10 flex items-center justify-center border border-[#222222] hover:bg-[#222222] hover:text-white transition-colors"
+            className="flex-shrink-0 w-12 h-12 rounded-full border border-[#222222] flex items-center justify-center hover:bg-[#222222] hover:text-white hover:-translate-y-0.5 transition-all"
           >
-            &#8592;
+            <svg
+              aria-hidden="true"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="15 18 9 12 15 6" />
+            </svg>
           </button>
           <AnimatePresence mode="wait">
             <motion.div
@@ -72,9 +84,21 @@ export default function Headshots() {
           <button
             aria-label="Next headshot"
             onClick={next}
-            className="flex-shrink-0 w-10 h-10 flex items-center justify-center border border-[#222222] hover:bg-[#222222] hover:text-white transition-colors"
+            className="flex-shrink-0 w-12 h-12 rounded-full border border-[#222222] flex items-center justify-center hover:bg-[#222222] hover:text-white hover:-translate-y-0.5 transition-all"
           >
-            &#8594;
+            <svg
+              aria-hidden="true"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
           </button>
         </div>
         <p

--- a/components/Headshots.tsx
+++ b/components/Headshots.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Image from "next/image";
 
 const headshots = [
@@ -17,6 +17,22 @@ export default function Headshots() {
   const prev = () =>
     setIndex((i) => (i - 1 + headshots.length) % headshots.length);
   const next = () => setIndex((i) => (i + 1) % headshots.length);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement
+      )
+        return;
+      if (e.key === "ArrowLeft")
+        setIndex((i) => (i - 1 + headshots.length) % headshots.length);
+      else if (e.key === "ArrowRight")
+        setIndex((i) => (i + 1) % headshots.length);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
 
   return (
     <section id="headshots" className="py-24 px-8 md:px-16 bg-white">

--- a/components/Headshots.tsx
+++ b/components/Headshots.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Image from "next/image";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 
 const headshots = [
   { src: "/images/headshot-1.jpg", alt: "Headshot 1" },
@@ -13,6 +14,7 @@ const headshots = [
 export default function Headshots() {
   const [index, setIndex] = useState(0);
   const base = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+  const reduce = useReducedMotion();
 
   const prev = () =>
     setIndex((i) => (i - 1 + headshots.length) % headshots.length);
@@ -48,15 +50,25 @@ export default function Headshots() {
           >
             &#8592;
           </button>
-          <div className="relative w-full max-w-2xl aspect-[3/4]">
-            <Image
-              src={`${base}${headshots[index].src}`}
-              alt={headshots[index].alt}
-              fill
-              className="object-cover"
-              priority={index === 0}
-            />
-          </div>
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={index}
+              initial={{ opacity: reduce ? 1 : 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: reduce ? 1 : 0 }}
+              transition={{ duration: reduce ? 0 : 0.3 }}
+              className="relative w-full max-w-2xl aspect-[3/4]"
+            >
+              <Image
+                src={`${base}${headshots[index].src}`}
+                alt={headshots[index].alt}
+                fill
+                sizes="(max-width: 1024px) 100vw, 672px"
+                className="object-cover"
+                priority={index === 0}
+              />
+            </motion.div>
+          </AnimatePresence>
           <button
             aria-label="Next headshot"
             onClick={next}

--- a/tests/Headshots.test.tsx
+++ b/tests/Headshots.test.tsx
@@ -16,6 +16,8 @@ vi.mock("framer-motion", () => ({
       transition,
       initial,
       exit,
+      whileInView,
+      viewport,
       ...props
     }: // eslint-disable-next-line @typescript-eslint/no-explicit-any
     any) => (
@@ -24,6 +26,8 @@ vi.mock("framer-motion", () => ({
         data-transition={JSON.stringify(transition)}
         data-initial={JSON.stringify(initial)}
         data-exit={JSON.stringify(exit)}
+        data-whileinview={JSON.stringify(whileInView)}
+        data-viewport={JSON.stringify(viewport)}
         {...props}
       >
         {children}
@@ -140,6 +144,18 @@ describe("Headshots", () => {
     });
   });
 
+  describe("entrance fade (6.8)", () => {
+    it("section content is wrapped in FadeInOnScroll", () => {
+      render(<Headshots />);
+      const heading = screen.getByRole("heading", { level: 2 });
+      const fadeAncestor = heading.closest("div[data-whileinview]");
+      expect(fadeAncestor).not.toBeNull();
+      expect(fadeAncestor!.getAttribute("data-whileinview")).toContain(
+        '"opacity":1'
+      );
+    });
+  });
+
   describe("round chevron buttons (6.7 + 6.3)", () => {
     it("prev button contains an SVG with aria-hidden true", () => {
       render(<Headshots />);
@@ -206,7 +222,7 @@ describe("Headshots", () => {
     it("reduced motion: transition duration is 0", () => {
       mockUseReducedMotion.mockReturnValue(true);
       render(<Headshots />);
-      const wrapper = document.querySelector("[data-transition]");
+      const wrapper = document.querySelector("[data-animate]");
       expect(
         JSON.parse(wrapper!.getAttribute("data-transition")!).duration
       ).toBe(0);

--- a/tests/Headshots.test.tsx
+++ b/tests/Headshots.test.tsx
@@ -109,6 +109,45 @@ describe("Headshots", () => {
     });
   });
 
+  describe("live counter + typography (6.5 + 6.6)", () => {
+    it("counter has aria-live polite", () => {
+      render(<Headshots />);
+      const counter = document.querySelector("[aria-live]");
+      expect(counter).toHaveAttribute("aria-live", "polite");
+    });
+
+    it("counter has aria-atomic true", () => {
+      render(<Headshots />);
+      const counter = document.querySelector("[aria-live]");
+      expect(counter).toHaveAttribute("aria-atomic", "true");
+    });
+
+    it("counter has sr-only span reading Image N of M", () => {
+      render(<Headshots />);
+      expect(screen.getByText("Image 1 of 4")).toBeInTheDocument();
+    });
+
+    it("counter has aria-hidden visible span with 01 — 04 style", () => {
+      render(<Headshots />);
+      const visibleSpan = document
+        .querySelector("[aria-live]")
+        ?.querySelector("[aria-hidden='true']");
+      expect(visibleSpan?.textContent).toMatch(/01\s*—\s*04/);
+    });
+
+    it("counter has font-playfair class", () => {
+      render(<Headshots />);
+      const counter = document.querySelector("[aria-live]");
+      expect(counter?.className).toContain("font-playfair");
+    });
+
+    it("counter has text-2xl or text-xl class", () => {
+      render(<Headshots />);
+      const counter = document.querySelector("[aria-live]");
+      expect(counter?.className).toMatch(/text-(xl|2xl)/);
+    });
+  });
+
   describe("priority loading (6.2)", () => {
     it("first image (index 0) has priority", () => {
       render(<Headshots />);

--- a/tests/Headshots.test.tsx
+++ b/tests/Headshots.test.tsx
@@ -1,6 +1,37 @@
+import React from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import Headshots from "../components/Headshots";
+
+const mockUseReducedMotion = vi.fn(() => false);
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  motion: {
+    div: ({
+      children,
+      animate,
+      transition,
+      initial,
+      exit,
+      ...props
+    }: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any) => (
+      <div
+        data-animate={JSON.stringify(animate)}
+        data-transition={JSON.stringify(transition)}
+        data-initial={JSON.stringify(initial)}
+        data-exit={JSON.stringify(exit)}
+        {...props}
+      >
+        {children}
+      </div>
+    ),
+  },
+  useReducedMotion: () => mockUseReducedMotion(),
+}));
 
 vi.mock("next/image", () => ({
   default: ({
@@ -106,6 +137,32 @@ describe("Headshots", () => {
       expect(screen.getByRole("img").getAttribute("src")).toContain(
         "headshot-1"
       );
+    });
+  });
+
+  describe("AnimatePresence crossfade (6.1)", () => {
+    it("renders a motion wrapper around the image", () => {
+      render(<Headshots />);
+      const wrapper = document.querySelector("[data-animate]");
+      expect(wrapper).toBeInTheDocument();
+    });
+
+    it("motion wrapper has opacity 1 animate target", () => {
+      render(<Headshots />);
+      const wrapper = document.querySelector("[data-animate]");
+      expect(JSON.parse(wrapper!.getAttribute("data-animate")!)).toMatchObject({
+        opacity: 1,
+      });
+    });
+
+    it("reduced motion: transition duration is 0", () => {
+      mockUseReducedMotion.mockReturnValue(true);
+      render(<Headshots />);
+      const wrapper = document.querySelector("[data-transition]");
+      expect(
+        JSON.parse(wrapper!.getAttribute("data-transition")!).duration
+      ).toBe(0);
+      mockUseReducedMotion.mockReturnValue(false);
     });
   });
 

--- a/tests/Headshots.test.tsx
+++ b/tests/Headshots.test.tsx
@@ -140,6 +140,54 @@ describe("Headshots", () => {
     });
   });
 
+  describe("round chevron buttons (6.7 + 6.3)", () => {
+    it("prev button contains an SVG with aria-hidden true", () => {
+      render(<Headshots />);
+      const prevBtn = screen.getByLabelText("Previous headshot");
+      const svg = prevBtn.querySelector("svg");
+      expect(svg).toBeInTheDocument();
+      expect(svg).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("next button contains an SVG with aria-hidden true", () => {
+      render(<Headshots />);
+      const nextBtn = screen.getByLabelText("Next headshot");
+      const svg = nextBtn.querySelector("svg");
+      expect(svg).toBeInTheDocument();
+      expect(svg).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("both buttons have rounded-full class", () => {
+      render(<Headshots />);
+      expect(screen.getByLabelText("Previous headshot").className).toContain(
+        "rounded-full"
+      );
+      expect(screen.getByLabelText("Next headshot").className).toContain(
+        "rounded-full"
+      );
+    });
+
+    it("both buttons have hover lift class", () => {
+      render(<Headshots />);
+      expect(screen.getByLabelText("Previous headshot").className).toContain(
+        "-translate-y-0.5"
+      );
+      expect(screen.getByLabelText("Next headshot").className).toContain(
+        "-translate-y-0.5"
+      );
+    });
+
+    it("button accessible names are preserved", () => {
+      render(<Headshots />);
+      expect(
+        screen.getByRole("button", { name: /previous headshot/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /next headshot/i })
+      ).toBeInTheDocument();
+    });
+  });
+
   describe("AnimatePresence crossfade (6.1)", () => {
     it("renders a motion wrapper around the image", () => {
       render(<Headshots />);

--- a/tests/Headshots.test.tsx
+++ b/tests/Headshots.test.tsx
@@ -71,6 +71,44 @@ describe("Headshots", () => {
     expect(screen.getByLabelText("Next headshot")).toBeInTheDocument();
   });
 
+  describe("keyboard navigation (6.4)", () => {
+    it("ArrowRight advances the index", () => {
+      render(<Headshots />);
+      fireEvent.keyDown(window, { key: "ArrowRight" });
+      expect(screen.getByRole("img").getAttribute("src")).toContain(
+        "headshot-2"
+      );
+    });
+
+    it("ArrowLeft wraps backward from index 0 to last", () => {
+      render(<Headshots />);
+      fireEvent.keyDown(window, { key: "ArrowLeft" });
+      expect(screen.getByRole("img").getAttribute("src")).toContain(
+        "headshot-4"
+      );
+    });
+
+    it("ArrowRight wraps forward from last to index 0", () => {
+      render(<Headshots />);
+      const next = screen.getByLabelText("Next headshot");
+      fireEvent.click(next);
+      fireEvent.click(next);
+      fireEvent.click(next);
+      fireEvent.keyDown(window, { key: "ArrowRight" });
+      expect(screen.getByRole("img").getAttribute("src")).toContain(
+        "headshot-1"
+      );
+    });
+
+    it("other keys do not change the index", () => {
+      render(<Headshots />);
+      fireEvent.keyDown(window, { key: "Enter" });
+      expect(screen.getByRole("img").getAttribute("src")).toContain(
+        "headshot-1"
+      );
+    });
+  });
+
   describe("priority loading (6.2)", () => {
     it("first image (index 0) has priority", () => {
       render(<Headshots />);

--- a/tests/Headshots.test.tsx
+++ b/tests/Headshots.test.tsx
@@ -6,12 +6,21 @@ vi.mock("next/image", () => ({
   default: ({
     src,
     alt,
+    priority,
     ...props
   }: {
     src: string;
     alt: string;
+    priority?: boolean;
     [key: string]: unknown;
-  }) => <img src={src} alt={alt} {...props} />,
+  }) => (
+    <img
+      src={src}
+      alt={alt}
+      data-priority={priority ? "true" : undefined}
+      {...props}
+    />
+  ),
 }));
 
 describe("Headshots", () => {
@@ -60,5 +69,20 @@ describe("Headshots", () => {
     render(<Headshots />);
     expect(screen.getByLabelText("Previous headshot")).toBeInTheDocument();
     expect(screen.getByLabelText("Next headshot")).toBeInTheDocument();
+  });
+
+  describe("priority loading (6.2)", () => {
+    it("first image (index 0) has priority", () => {
+      render(<Headshots />);
+      const img = screen.getByRole("img");
+      expect(img).toHaveAttribute("data-priority", "true");
+    });
+
+    it("subsequent images do not have priority", () => {
+      render(<Headshots />);
+      fireEvent.click(screen.getByLabelText("Next headshot"));
+      const img = screen.getByRole("img");
+      expect(img).not.toHaveAttribute("data-priority");
+    });
   });
 });


### PR DESCRIPTION
## Summary

Polish the headshots carousel per Phase 6 plan (`plan/phase-6.md`).

- Crossfade between images via `AnimatePresence` (HS-01)
- Priority loading: only first image (HS-03)
- Arrow glyph a11y → replaced by chevron SVGs (HS-04)
- Keyboard arrow navigation (HS-05)
- `aria-live` counter announcement (HS-06)
- Counter typography: Playfair `01 — 04` style (HS-08)
- Round chevron arrow buttons + hover lift (HS-09)
- Entrance fade via `FadeInOnScroll` (G-01)

## Issues

Closes #95, #96, #97, #98, #99, #100

Made with [Cursor](https://cursor.com)