### PR TITLE
feat(headshots): only first image gets priority load

### DIFF
--- a/components/Headshots.tsx
+++ b/components/Headshots.tsx
@@ -38,7 +38,7 @@ export default function Headshots() {
               alt={headshots[index].alt}
               fill
               className="object-cover"
-              priority
+              priority={index === 0}
             />
           </div>
           <button

--- a/tests/Headshots.test.tsx
+++ b/tests/Headshots.test.tsx
@@ -6,12 +6,21 @@ vi.mock("next/image", () => ({
   default: ({
     src,
     alt,
+    priority,
     ...props
   }: {
     src: string;
     alt: string;
+    priority?: boolean;
     [key: string]: unknown;
-  }) => <img src={src} alt={alt} {...props} />,
+  }) => (
+    <img
+      src={src}
+      alt={alt}
+      data-priority={priority ? "true" : undefined}
+      {...props}
+    />
+  ),
 }));
 
 describe("Headshots", () => {
@@ -60,5 +69,20 @@ describe("Headshots", () => {
     render(<Headshots />);
     expect(screen.getByLabelText("Previous headshot")).toBeInTheDocument();
     expect(screen.getByLabelText("Next headshot")).toBeInTheDocument();
+  });
+
+  describe("priority loading (6.2)", () => {
+    it("first image (index 0) has priority", () => {
+      render(<Headshots />);
+      const img = screen.getByRole("img");
+      expect(img).toHaveAttribute("data-priority", "true");
+    });
+
+    it("subsequent images do not have priority", () => {
+      render(<Headshots />);
+      fireEvent.click(screen.getByLabelText("Next headshot"));
+      const img = screen.getByRole("img");
+      expect(img).not.toHaveAttribute("data-priority");
+    });
   });
 });


### PR DESCRIPTION
Closes #95

## Changes

- `components/Headshots.tsx`: change `priority` from always-true to `priority={index === 0}`
- `tests/Headshots.test.tsx`: update next/image mock to surface `priority` as `data-priority`; add tests verifying first image has priority and subsequent do not

**QA-PLAN ID:** HS-03

Made with [Cursor](https://cursor.com)