### PR TITLE
feat(headshots): keyboard arrow navigation for carousel

### DIFF
--- a/components/Headshots.tsx
+++ b/components/Headshots.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Image from "next/image";
 
 const headshots = [
@@ -17,6 +17,22 @@ export default function Headshots() {
   const prev = () =>
     setIndex((i) => (i - 1 + headshots.length) % headshots.length);
   const next = () => setIndex((i) => (i + 1) % headshots.length);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement
+      )
+        return;
+      if (e.key === "ArrowLeft")
+        setIndex((i) => (i - 1 + headshots.length) % headshots.length);
+      else if (e.key === "ArrowRight")
+        setIndex((i) => (i + 1) % headshots.length);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
 
   return (
     <section id="headshots" className="py-24 px-8 md:px-16 bg-white">

--- a/tests/Headshots.test.tsx
+++ b/tests/Headshots.test.tsx
@@ -71,6 +71,44 @@ describe("Headshots", () => {
     expect(screen.getByLabelText("Next headshot")).toBeInTheDocument();
   });
 
+  describe("keyboard navigation (6.4)", () => {
+    it("ArrowRight advances the index", () => {
+      render(<Headshots />);
+      fireEvent.keyDown(window, { key: "ArrowRight" });
+      expect(screen.getByRole("img").getAttribute("src")).toContain(
+        "headshot-2"
+      );
+    });
+
+    it("ArrowLeft wraps backward from index 0 to last", () => {
+      render(<Headshots />);
+      fireEvent.keyDown(window, { key: "ArrowLeft" });
+      expect(screen.getByRole("img").getAttribute("src")).toContain(
+        "headshot-4"
+      );
+    });
+
+    it("ArrowRight wraps forward from last to index 0", () => {
+      render(<Headshots />);
+      const next = screen.getByLabelText("Next headshot");
+      fireEvent.click(next);
+      fireEvent.click(next);
+      fireEvent.click(next);
+      fireEvent.keyDown(window, { key: "ArrowRight" });
+      expect(screen.getByRole("img").getAttribute("src")).toContain(
+        "headshot-1"
+      );
+    });
+
+    it("other keys do not change the index", () => {
+      render(<Headshots />);
+      fireEvent.keyDown(window, { key: "Enter" });
+      expect(screen.getByRole("img").getAttribute("src")).toContain(
+        "headshot-1"
+      );
+    });
+  });
+
   describe("priority loading (6.2)", () => {
     it("first image (index 0) has priority", () => {
       render(<Headshots />);


### PR DESCRIPTION
Closes #96

## Changes

- `components/Headshots.tsx`: global `keydown` listener for ArrowLeft/ArrowRight with stale-closure-free functional setIndex, skip inside inputs, cleanup on unmount
- `tests/Headshots.test.tsx`: 4 keyboard nav tests covering advance, backward wrap, forward wrap, and no-op for other keys

**QA-PLAN ID:** HS-05

Made with [Cursor](https://cursor.com)