### PR TITLE
feat(headshots): aria-live counter and Playfair typography

### DIFF
--- a/components/Headshots.tsx
+++ b/components/Headshots.tsx
@@ -65,8 +65,18 @@ export default function Headshots() {
             &#8594;
           </button>
         </div>
-        <p className="text-center text-sm text-gray-400 mt-4">
-          {index + 1} / {headshots.length}
+        <p
+          aria-live="polite"
+          aria-atomic="true"
+          className="text-center font-playfair text-2xl text-[#222222] mt-4"
+        >
+          <span className="sr-only">
+            Image {index + 1} of {headshots.length}
+          </span>
+          <span aria-hidden="true">
+            {String(index + 1).padStart(2, "0")} &mdash;{" "}
+            {String(headshots.length).padStart(2, "0")}
+          </span>
         </p>
       </div>
     </section>

--- a/tests/Headshots.test.tsx
+++ b/tests/Headshots.test.tsx
@@ -109,6 +109,45 @@ describe("Headshots", () => {
     });
   });
 
+  describe("live counter + typography (6.5 + 6.6)", () => {
+    it("counter has aria-live polite", () => {
+      render(<Headshots />);
+      const counter = document.querySelector("[aria-live]");
+      expect(counter).toHaveAttribute("aria-live", "polite");
+    });
+
+    it("counter has aria-atomic true", () => {
+      render(<Headshots />);
+      const counter = document.querySelector("[aria-live]");
+      expect(counter).toHaveAttribute("aria-atomic", "true");
+    });
+
+    it("counter has sr-only span reading Image N of M", () => {
+      render(<Headshots />);
+      expect(screen.getByText("Image 1 of 4")).toBeInTheDocument();
+    });
+
+    it("counter has aria-hidden visible span with 01 — 04 style", () => {
+      render(<Headshots />);
+      const visibleSpan = document
+        .querySelector("[aria-live]")
+        ?.querySelector("[aria-hidden='true']");
+      expect(visibleSpan?.textContent).toMatch(/01\s*—\s*04/);
+    });
+
+    it("counter has font-playfair class", () => {
+      render(<Headshots />);
+      const counter = document.querySelector("[aria-live]");
+      expect(counter?.className).toContain("font-playfair");
+    });
+
+    it("counter has text-2xl or text-xl class", () => {
+      render(<Headshots />);
+      const counter = document.querySelector("[aria-live]");
+      expect(counter?.className).toMatch(/text-(xl|2xl)/);
+    });
+  });
+
   describe("priority loading (6.2)", () => {
     it("first image (index 0) has priority", () => {
       render(<Headshots />);


### PR DESCRIPTION
Closes #97

## Changes

- `components/Headshots.tsx`: `aria-live="polite"` + `aria-atomic="true"` on counter; sr-only "Image N of M" span; aria-hidden "01 — 04" styled span; Playfair `text-2xl` classes
- `tests/Headshots.test.tsx`: 6 tests covering live region attributes, sr-only text, visible format, and typography classes

**QA-PLAN IDs:** HS-06, HS-08

Made with [Cursor](https://cursor.com)