### PR TITLE
feat(headshots): AnimatePresence crossfade with reduced-motion support

### DIFF
--- a/components/Headshots.tsx
+++ b/components/Headshots.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Image from "next/image";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 
 const headshots = [
   { src: "/images/headshot-1.jpg", alt: "Headshot 1" },
@@ -13,6 +14,7 @@ const headshots = [
 export default function Headshots() {
   const [index, setIndex] = useState(0);
   const base = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+  const reduce = useReducedMotion();
 
   const prev = () =>
     setIndex((i) => (i - 1 + headshots.length) % headshots.length);
@@ -48,15 +50,25 @@ export default function Headshots() {
           >
             &#8592;
           </button>
-          <div className="relative w-full max-w-2xl aspect-[3/4]">
-            <Image
-              src={`${base}${headshots[index].src}`}
-              alt={headshots[index].alt}
-              fill
-              className="object-cover"
-              priority={index === 0}
-            />
-          </div>
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={index}
+              initial={{ opacity: reduce ? 1 : 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: reduce ? 1 : 0 }}
+              transition={{ duration: reduce ? 0 : 0.3 }}
+              className="relative w-full max-w-2xl aspect-[3/4]"
+            >
+              <Image
+                src={`${base}${headshots[index].src}`}
+                alt={headshots[index].alt}
+                fill
+                sizes="(max-width: 1024px) 100vw, 672px"
+                className="object-cover"
+                priority={index === 0}
+              />
+            </motion.div>
+          </AnimatePresence>
           <button
             aria-label="Next headshot"
             onClick={next}

--- a/tests/Headshots.test.tsx
+++ b/tests/Headshots.test.tsx
@@ -1,6 +1,37 @@
+import React from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import Headshots from "../components/Headshots";
+
+const mockUseReducedMotion = vi.fn(() => false);
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  motion: {
+    div: ({
+      children,
+      animate,
+      transition,
+      initial,
+      exit,
+      ...props
+    }: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any) => (
+      <div
+        data-animate={JSON.stringify(animate)}
+        data-transition={JSON.stringify(transition)}
+        data-initial={JSON.stringify(initial)}
+        data-exit={JSON.stringify(exit)}
+        {...props}
+      >
+        {children}
+      </div>
+    ),
+  },
+  useReducedMotion: () => mockUseReducedMotion(),
+}));
 
 vi.mock("next/image", () => ({
   default: ({
@@ -106,6 +137,32 @@ describe("Headshots", () => {
       expect(screen.getByRole("img").getAttribute("src")).toContain(
         "headshot-1"
       );
+    });
+  });
+
+  describe("AnimatePresence crossfade (6.1)", () => {
+    it("renders a motion wrapper around the image", () => {
+      render(<Headshots />);
+      const wrapper = document.querySelector("[data-animate]");
+      expect(wrapper).toBeInTheDocument();
+    });
+
+    it("motion wrapper has opacity 1 animate target", () => {
+      render(<Headshots />);
+      const wrapper = document.querySelector("[data-animate]");
+      expect(JSON.parse(wrapper!.getAttribute("data-animate")!)).toMatchObject({
+        opacity: 1,
+      });
+    });
+
+    it("reduced motion: transition duration is 0", () => {
+      mockUseReducedMotion.mockReturnValue(true);
+      render(<Headshots />);
+      const wrapper = document.querySelector("[data-transition]");
+      expect(
+        JSON.parse(wrapper!.getAttribute("data-transition")!).duration
+      ).toBe(0);
+      mockUseReducedMotion.mockReturnValue(false);
     });
   });
 


### PR DESCRIPTION
Closes #98

## Changes

- `components/Headshots.tsx`: wrap active image in `<AnimatePresence mode="wait">` + `motion.div` keyed on index; crossfade 300ms; instant swap when `prefers-reduced-motion` is on; add `sizes` prop
- `tests/Headshots.test.tsx`: framer-motion mock with `AnimatePresence` passthrough and `motion.div` data attrs; 3 crossfade tests

**QA-PLAN ID:** HS-01

Made with [Cursor](https://cursor.com)