### PR TITLE
feat(headshots): round chevron buttons with hover lift

### DIFF
--- a/components/Headshots.tsx
+++ b/components/Headshots.tsx
@@ -46,9 +46,21 @@ export default function Headshots() {
           <button
             aria-label="Previous headshot"
             onClick={prev}
-            className="flex-shrink-0 w-10 h-10 flex items-center justify-center border border-[#222222] hover:bg-[#222222] hover:text-white transition-colors"
+            className="flex-shrink-0 w-12 h-12 rounded-full border border-[#222222] flex items-center justify-center hover:bg-[#222222] hover:text-white hover:-translate-y-0.5 transition-all"
           >
-            &#8592;
+            <svg
+              aria-hidden="true"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="15 18 9 12 15 6" />
+            </svg>
           </button>
           <AnimatePresence mode="wait">
             <motion.div
@@ -72,9 +84,21 @@ export default function Headshots() {
           <button
             aria-label="Next headshot"
             onClick={next}
-            className="flex-shrink-0 w-10 h-10 flex items-center justify-center border border-[#222222] hover:bg-[#222222] hover:text-white transition-colors"
+            className="flex-shrink-0 w-12 h-12 rounded-full border border-[#222222] flex items-center justify-center hover:bg-[#222222] hover:text-white hover:-translate-y-0.5 transition-all"
           >
-            &#8594;
+            <svg
+              aria-hidden="true"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
           </button>
         </div>
         <p

--- a/tests/Headshots.test.tsx
+++ b/tests/Headshots.test.tsx
@@ -140,6 +140,54 @@ describe("Headshots", () => {
     });
   });
 
+  describe("round chevron buttons (6.7 + 6.3)", () => {
+    it("prev button contains an SVG with aria-hidden true", () => {
+      render(<Headshots />);
+      const prevBtn = screen.getByLabelText("Previous headshot");
+      const svg = prevBtn.querySelector("svg");
+      expect(svg).toBeInTheDocument();
+      expect(svg).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("next button contains an SVG with aria-hidden true", () => {
+      render(<Headshots />);
+      const nextBtn = screen.getByLabelText("Next headshot");
+      const svg = nextBtn.querySelector("svg");
+      expect(svg).toBeInTheDocument();
+      expect(svg).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("both buttons have rounded-full class", () => {
+      render(<Headshots />);
+      expect(screen.getByLabelText("Previous headshot").className).toContain(
+        "rounded-full"
+      );
+      expect(screen.getByLabelText("Next headshot").className).toContain(
+        "rounded-full"
+      );
+    });
+
+    it("both buttons have hover lift class", () => {
+      render(<Headshots />);
+      expect(screen.getByLabelText("Previous headshot").className).toContain(
+        "-translate-y-0.5"
+      );
+      expect(screen.getByLabelText("Next headshot").className).toContain(
+        "-translate-y-0.5"
+      );
+    });
+
+    it("button accessible names are preserved", () => {
+      render(<Headshots />);
+      expect(
+        screen.getByRole("button", { name: /previous headshot/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /next headshot/i })
+      ).toBeInTheDocument();
+    });
+  });
+
   describe("AnimatePresence crossfade (6.1)", () => {
     it("renders a motion wrapper around the image", () => {
       render(<Headshots />);


### PR DESCRIPTION
Closes #99

## Changes

- `components/Headshots.tsx`: replace square arrow-glyph buttons with `rounded-full` chevron-SVG buttons; `aria-hidden` SVGs; `hover:-translate-y-0.5 transition-all` lift effect
- `tests/Headshots.test.tsx`: 5 tests verifying SVG aria-hidden, rounded-full, lift class, and accessible names

**QA-PLAN IDs:** HS-04, HS-09

Made with [Cursor](https://cursor.com)