### PR TITLE
feat(headshots): entrance fade via FadeInOnScroll

### DIFF
--- a/components/Headshots.tsx
+++ b/components/Headshots.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import Image from "next/image";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import FadeInOnScroll from "./FadeInOnScroll";
 
 const headshots = [
   { src: "/images/headshot-1.jpg", alt: "Headshot 1" },
@@ -38,83 +39,85 @@ export default function Headshots() {
 
   return (
     <section id="headshots" className="py-24 px-8 md:px-16 bg-white">
-      <div className="max-w-6xl mx-auto">
-        <h2 className="font-playfair text-4xl font-semibold text-[#222222] mb-12">
-          Headshots
-        </h2>
-        <div className="relative flex items-center justify-center gap-4">
-          <button
-            aria-label="Previous headshot"
-            onClick={prev}
-            className="flex-shrink-0 w-12 h-12 rounded-full border border-[#222222] flex items-center justify-center hover:bg-[#222222] hover:text-white hover:-translate-y-0.5 transition-all"
+      <FadeInOnScroll>
+        <div className="max-w-6xl mx-auto">
+          <h2 className="font-playfair text-4xl font-semibold text-[#222222] mb-12">
+            Headshots
+          </h2>
+          <div className="relative flex items-center justify-center gap-4">
+            <button
+              aria-label="Previous headshot"
+              onClick={prev}
+              className="flex-shrink-0 w-12 h-12 rounded-full border border-[#222222] flex items-center justify-center hover:bg-[#222222] hover:text-white hover:-translate-y-0.5 transition-all"
+            >
+              <svg
+                aria-hidden="true"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <polyline points="15 18 9 12 15 6" />
+              </svg>
+            </button>
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={index}
+                initial={{ opacity: reduce ? 1 : 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: reduce ? 1 : 0 }}
+                transition={{ duration: reduce ? 0 : 0.3 }}
+                className="relative w-full max-w-2xl aspect-[3/4]"
+              >
+                <Image
+                  src={`${base}${headshots[index].src}`}
+                  alt={headshots[index].alt}
+                  fill
+                  sizes="(max-width: 1024px) 100vw, 672px"
+                  className="object-cover"
+                  priority={index === 0}
+                />
+              </motion.div>
+            </AnimatePresence>
+            <button
+              aria-label="Next headshot"
+              onClick={next}
+              className="flex-shrink-0 w-12 h-12 rounded-full border border-[#222222] flex items-center justify-center hover:bg-[#222222] hover:text-white hover:-translate-y-0.5 transition-all"
+            >
+              <svg
+                aria-hidden="true"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <polyline points="9 18 15 12 9 6" />
+              </svg>
+            </button>
+          </div>
+          <p
+            aria-live="polite"
+            aria-atomic="true"
+            className="text-center font-playfair text-2xl text-[#222222] mt-4"
           >
-            <svg
-              aria-hidden="true"
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <polyline points="15 18 9 12 15 6" />
-            </svg>
-          </button>
-          <AnimatePresence mode="wait">
-            <motion.div
-              key={index}
-              initial={{ opacity: reduce ? 1 : 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: reduce ? 1 : 0 }}
-              transition={{ duration: reduce ? 0 : 0.3 }}
-              className="relative w-full max-w-2xl aspect-[3/4]"
-            >
-              <Image
-                src={`${base}${headshots[index].src}`}
-                alt={headshots[index].alt}
-                fill
-                sizes="(max-width: 1024px) 100vw, 672px"
-                className="object-cover"
-                priority={index === 0}
-              />
-            </motion.div>
-          </AnimatePresence>
-          <button
-            aria-label="Next headshot"
-            onClick={next}
-            className="flex-shrink-0 w-12 h-12 rounded-full border border-[#222222] flex items-center justify-center hover:bg-[#222222] hover:text-white hover:-translate-y-0.5 transition-all"
-          >
-            <svg
-              aria-hidden="true"
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <polyline points="9 18 15 12 9 6" />
-            </svg>
-          </button>
+            <span className="sr-only">
+              Image {index + 1} of {headshots.length}
+            </span>
+            <span aria-hidden="true">
+              {String(index + 1).padStart(2, "0")} &mdash;{" "}
+              {String(headshots.length).padStart(2, "0")}
+            </span>
+          </p>
         </div>
-        <p
-          aria-live="polite"
-          aria-atomic="true"
-          className="text-center font-playfair text-2xl text-[#222222] mt-4"
-        >
-          <span className="sr-only">
-            Image {index + 1} of {headshots.length}
-          </span>
-          <span aria-hidden="true">
-            {String(index + 1).padStart(2, "0")} &mdash;{" "}
-            {String(headshots.length).padStart(2, "0")}
-          </span>
-        </p>
-      </div>
+      </FadeInOnScroll>
     </section>
   );
 }

--- a/tests/Headshots.test.tsx
+++ b/tests/Headshots.test.tsx
@@ -16,6 +16,8 @@ vi.mock("framer-motion", () => ({
       transition,
       initial,
       exit,
+      whileInView,
+      viewport,
       ...props
     }: // eslint-disable-next-line @typescript-eslint/no-explicit-any
     any) => (
@@ -24,6 +26,8 @@ vi.mock("framer-motion", () => ({
         data-transition={JSON.stringify(transition)}
         data-initial={JSON.stringify(initial)}
         data-exit={JSON.stringify(exit)}
+        data-whileinview={JSON.stringify(whileInView)}
+        data-viewport={JSON.stringify(viewport)}
         {...props}
       >
         {children}
@@ -140,6 +144,18 @@ describe("Headshots", () => {
     });
   });
 
+  describe("entrance fade (6.8)", () => {
+    it("section content is wrapped in FadeInOnScroll", () => {
+      render(<Headshots />);
+      const heading = screen.getByRole("heading", { level: 2 });
+      const fadeAncestor = heading.closest("div[data-whileinview]");
+      expect(fadeAncestor).not.toBeNull();
+      expect(fadeAncestor!.getAttribute("data-whileinview")).toContain(
+        '"opacity":1'
+      );
+    });
+  });
+
   describe("round chevron buttons (6.7 + 6.3)", () => {
     it("prev button contains an SVG with aria-hidden true", () => {
       render(<Headshots />);
@@ -206,7 +222,7 @@ describe("Headshots", () => {
     it("reduced motion: transition duration is 0", () => {
       mockUseReducedMotion.mockReturnValue(true);
       render(<Headshots />);
-      const wrapper = document.querySelector("[data-transition]");
+      const wrapper = document.querySelector("[data-animate]");
       expect(
         JSON.parse(wrapper!.getAttribute("data-transition")!).duration
       ).toBe(0);


### PR DESCRIPTION
Closes #100

## Changes

- `components/Headshots.tsx`: wrap `max-w-6xl` inner div in `<FadeInOnScroll>` for entrance animation
- `tests/Headshots.test.tsx`: extend framer-motion mock with `whileInView`/`viewport` data attrs; add entrance fade test; fix reduced-motion test to target crossfade div specifically

**QA-PLAN ID:** G-01

Made with [Cursor](https://cursor.com)