### PR TITLE
feat(stats): add id="stats" and Casting eyebrow heading

### DIFF
--- a/components/Stats.tsx
+++ b/components/Stats.tsx
@@ -7,18 +7,26 @@ const stats = [
 
 export default function Stats() {
   return (
-    <section className="py-16 px-8 md:px-16 border-t border-b border-gray-100">
-      <div className="max-w-6xl mx-auto grid grid-cols-2 md:grid-cols-4 gap-8 text-center">
-        {stats.map(({ label, value }) => (
-          <div key={label}>
-            <p className="text-xs uppercase tracking-widest text-gray-400 mb-1">
-              {label}
-            </p>
-            <p className="font-playfair text-2xl font-semibold text-[#222222]">
-              {value}
-            </p>
-          </div>
-        ))}
+    <section
+      id="stats"
+      className="py-16 px-8 md:px-16 border-t border-b border-gray-100"
+    >
+      <div className="max-w-6xl mx-auto">
+        <p className="text-xs uppercase tracking-[0.2em] text-gray-500 mb-8 text-center">
+          Casting
+        </p>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-8 text-center">
+          {stats.map(({ label, value }) => (
+            <div key={label}>
+              <p className="text-xs uppercase tracking-widest text-gray-400 mb-1">
+                {label}
+              </p>
+              <p className="font-playfair text-2xl font-semibold text-[#222222]">
+                {value}
+              </p>
+            </div>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/tests/Stats.test.tsx
+++ b/tests/Stats.test.tsx
@@ -18,4 +18,21 @@ describe("Stats", () => {
     expect(screen.getByText("Black")).toBeInTheDocument();
     expect(screen.getByText("Brown")).toBeInTheDocument();
   });
+
+  it("section has id='stats' for anchor navigation", () => {
+    const { container } = render(<Stats />);
+    expect(container.querySelector("#stats")).toBeInTheDocument();
+  });
+
+  it("renders eyebrow heading 'Casting' above the stats grid", () => {
+    render(<Stats />);
+    expect(screen.getByText("Casting")).toBeInTheDocument();
+  });
+
+  it("eyebrow has uppercase and tracking class", () => {
+    render(<Stats />);
+    const eyebrow = screen.getByText("Casting");
+    expect(eyebrow.className).toMatch(/uppercase/);
+    expect(eyebrow.className).toMatch(/tracking-/);
+  });
 });


### PR DESCRIPTION
Closes #108

## Changes

- Add `id="stats"` to the stats section for `/#stats` anchor navigation
- Add "Casting" eyebrow heading above the stats grid (uppercase, letter-spaced)
- Wrap grid in `max-w-6xl mx-auto` div to accommodate the eyebrow layout

## Tests

- Section has `id="stats"` for anchor navigation
- Eyebrow text "Casting" renders above the stats grid
- Eyebrow has uppercase and tracking classes

Made with [Cursor](https://cursor.com)