### PR TITLE
phase-7: Stats component polish

### DIFF
--- a/components/Stats.tsx
+++ b/components/Stats.tsx
@@ -7,18 +7,26 @@ const stats = [
 
 export default function Stats() {
   return (
-    <section className="py-16 px-8 md:px-16 border-t border-b border-gray-100">
-      <div className="max-w-6xl mx-auto grid grid-cols-2 md:grid-cols-4 gap-8 text-center">
-        {stats.map(({ label, value }) => (
-          <div key={label}>
-            <p className="text-xs uppercase tracking-widest text-gray-400 mb-1">
-              {label}
-            </p>
-            <p className="font-playfair text-2xl font-semibold text-[#222222]">
-              {value}
-            </p>
-          </div>
-        ))}
+    <section
+      id="stats"
+      className="py-16 px-8 md:px-16 border-t border-b border-gray-100"
+    >
+      <div className="max-w-6xl mx-auto">
+        <p className="text-xs uppercase tracking-[0.2em] text-gray-500 mb-8 text-center">
+          Casting
+        </p>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-8 text-center">
+          {stats.map(({ label, value }) => (
+            <div key={label}>
+              <p className="text-xs uppercase tracking-widest text-gray-400 mb-1">
+                {label}
+              </p>
+              <p className="font-playfair text-2xl font-semibold text-[#222222]">
+                {value}
+              </p>
+            </div>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/components/Stats.tsx
+++ b/components/Stats.tsx
@@ -9,7 +9,7 @@ export default function Stats() {
   return (
     <section
       id="stats"
-      className="py-16 px-8 md:px-16 border-t border-b border-gray-100"
+      className="py-16 px-8 md:px-16 border-t border-gray-100"
     >
       <div className="max-w-6xl mx-auto">
         <p className="text-xs uppercase tracking-[0.2em] text-gray-500 mb-8 text-center">

--- a/components/Stats.tsx
+++ b/components/Stats.tsx
@@ -1,3 +1,5 @@
+import FadeInOnScroll from "./FadeInOnScroll";
+
 const stats = [
   { label: "Height", value: `6' 0"` },
   { label: "Weight", value: "185 lbs" },
@@ -11,23 +13,25 @@ export default function Stats() {
       id="stats"
       className="py-16 px-8 md:px-16 border-t border-gray-100"
     >
-      <div className="max-w-6xl mx-auto">
-        <p className="text-xs uppercase tracking-[0.2em] text-gray-500 mb-8 text-center">
-          Casting
-        </p>
-        <div className="grid grid-cols-2 md:grid-cols-4 md:divide-x md:divide-gray-100 gap-y-8 md:gap-x-0 text-center">
-          {stats.map(({ label, value }) => (
-            <div key={label} className="md:px-4">
-              <p className="text-xs uppercase tracking-widest text-gray-400 mb-2">
-                {label}
-              </p>
-              <p className="font-playfair text-3xl md:text-4xl font-semibold text-[#222222]">
-                {value}
-              </p>
-            </div>
-          ))}
+      <FadeInOnScroll>
+        <div className="max-w-6xl mx-auto">
+          <p className="text-xs uppercase tracking-[0.2em] text-gray-500 mb-8 text-center">
+            Casting
+          </p>
+          <div className="grid grid-cols-2 md:grid-cols-4 md:divide-x md:divide-gray-100 gap-y-8 md:gap-x-0 text-center">
+            {stats.map(({ label, value }) => (
+              <div key={label} className="md:px-4">
+                <p className="text-xs uppercase tracking-widest text-gray-400 mb-2">
+                  {label}
+                </p>
+                <p className="font-playfair text-3xl md:text-4xl font-semibold text-[#222222]">
+                  {value}
+                </p>
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
+      </FadeInOnScroll>
     </section>
   );
 }

--- a/components/Stats.tsx
+++ b/components/Stats.tsx
@@ -15,13 +15,13 @@ export default function Stats() {
         <p className="text-xs uppercase tracking-[0.2em] text-gray-500 mb-8 text-center">
           Casting
         </p>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-8 text-center">
+        <div className="grid grid-cols-2 md:grid-cols-4 md:divide-x md:divide-gray-100 gap-y-8 md:gap-x-0 text-center">
           {stats.map(({ label, value }) => (
-            <div key={label}>
-              <p className="text-xs uppercase tracking-widest text-gray-400 mb-1">
+            <div key={label} className="md:px-4">
+              <p className="text-xs uppercase tracking-widest text-gray-400 mb-2">
                 {label}
               </p>
-              <p className="font-playfair text-2xl font-semibold text-[#222222]">
+              <p className="font-playfair text-3xl md:text-4xl font-semibold text-[#222222]">
                 {value}
               </p>
             </div>

--- a/tests/Stats.test.tsx
+++ b/tests/Stats.test.tsx
@@ -42,4 +42,19 @@ describe("Stats", () => {
     expect(section.className).toMatch(/\bborder-t\b/);
     expect(section.className).not.toMatch(/\bborder-b\b/);
   });
+
+  it("stat values use larger Playfair display size", () => {
+    const { container } = render(<Stats />);
+    const valueEls = container.querySelectorAll(".font-playfair");
+    expect(valueEls.length).toBeGreaterThan(0);
+    valueEls.forEach((el) => {
+      expect(el.className).toMatch(/text-3xl|text-4xl/);
+    });
+  });
+
+  it("stats grid has divide-x class for hairline dividers", () => {
+    const { container } = render(<Stats />);
+    const grid = container.querySelector(".grid");
+    expect(grid?.className).toMatch(/divide-x/);
+  });
 });

--- a/tests/Stats.test.tsx
+++ b/tests/Stats.test.tsx
@@ -18,4 +18,21 @@ describe("Stats", () => {
     expect(screen.getByText("Black")).toBeInTheDocument();
     expect(screen.getByText("Brown")).toBeInTheDocument();
   });
+
+  it("section has id='stats' for anchor navigation", () => {
+    const { container } = render(<Stats />);
+    expect(container.querySelector("#stats")).toBeInTheDocument();
+  });
+
+  it("renders eyebrow heading 'Casting' above the stats grid", () => {
+    render(<Stats />);
+    expect(screen.getByText("Casting")).toBeInTheDocument();
+  });
+
+  it("eyebrow has uppercase and tracking class", () => {
+    render(<Stats />);
+    const eyebrow = screen.getByText("Casting");
+    expect(eyebrow.className).toMatch(/uppercase/);
+    expect(eyebrow.className).toMatch(/tracking-/);
+  });
 });

--- a/tests/Stats.test.tsx
+++ b/tests/Stats.test.tsx
@@ -1,6 +1,33 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import Stats from "../components/Stats";
+
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      className,
+      initial,
+      whileInView,
+      viewport,
+      transition,
+      ...props
+    }: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any) => (
+      <div
+        className={className}
+        data-initial={JSON.stringify(initial)}
+        data-whileinview={JSON.stringify(whileInView)}
+        data-viewport={JSON.stringify(viewport)}
+        data-transition={JSON.stringify(transition)}
+        {...props}
+      >
+        {children}
+      </div>
+    ),
+  },
+  useReducedMotion: vi.fn(() => false),
+}));
 
 describe("Stats", () => {
   it("renders all four stat labels", () => {
@@ -56,5 +83,15 @@ describe("Stats", () => {
     const { container } = render(<Stats />);
     const grid = container.querySelector(".grid");
     expect(grid?.className).toMatch(/divide-x/);
+  });
+
+  it("stats content is wrapped in FadeInOnScroll", () => {
+    render(<Stats />);
+    const eyebrow = screen.getByText("Casting");
+    const fadeAncestor = eyebrow.closest("div[data-whileinview]");
+    expect(fadeAncestor).not.toBeNull();
+    expect(fadeAncestor!.getAttribute("data-whileinview")).toContain(
+      '"opacity":1'
+    );
   });
 });

--- a/tests/Stats.test.tsx
+++ b/tests/Stats.test.tsx
@@ -35,4 +35,11 @@ describe("Stats", () => {
     expect(eyebrow.className).toMatch(/uppercase/);
     expect(eyebrow.className).toMatch(/tracking-/);
   });
+
+  it("section has border-t but not border-b", () => {
+    const { container } = render(<Stats />);
+    const section = container.querySelector("#stats")!;
+    expect(section.className).toMatch(/\bborder-t\b/);
+    expect(section.className).not.toMatch(/\bborder-b\b/);
+  });
 });


### PR DESCRIPTION
## Phase 7 — Stats (`components/Stats.tsx`)

Polish pass on the casting-stats row addressing QA-PLAN IDs S-01, S-02, S-03, S-05, G-01.

### Sub-PRs

- **#112** ✅ `id="stats"` + "Casting" eyebrow heading (closes #108)
- **#109** Single top hairline, remove bottom border — _pending_
- **#110** Larger Playfair typography + hairline dividers — _pending_
- **#111** Entrance fade via `<FadeInOnScroll>` — _pending_

---
> Draft — do not merge until all sub-PRs are merged and reviewed.

Made with [Cursor](https://cursor.com)