### PR TITLE
feat(stats): remove bottom border, keep only top hairline

### DIFF
--- a/components/Stats.tsx
+++ b/components/Stats.tsx
@@ -9,7 +9,7 @@ export default function Stats() {
   return (
     <section
       id="stats"
-      className="py-16 px-8 md:px-16 border-t border-b border-gray-100"
+      className="py-16 px-8 md:px-16 border-t border-gray-100"
     >
       <div className="max-w-6xl mx-auto">
         <p className="text-xs uppercase tracking-[0.2em] text-gray-500 mb-8 text-center">

--- a/tests/Stats.test.tsx
+++ b/tests/Stats.test.tsx
@@ -35,4 +35,11 @@ describe("Stats", () => {
     expect(eyebrow.className).toMatch(/uppercase/);
     expect(eyebrow.className).toMatch(/tracking-/);
   });
+
+  it("section has border-t but not border-b", () => {
+    const { container } = render(<Stats />);
+    const section = container.querySelector("#stats")!;
+    expect(section.className).toMatch(/\bborder-t\b/);
+    expect(section.className).not.toMatch(/\bborder-b\b/);
+  });
 });


### PR DESCRIPTION
Closes #109

## Changes

- Remove `border-b` from the stats section, keeping only `border-t`
- Section now reads as a transition into the next section rather than a contained box

## Tests

- Section has `border-t` but NOT `border-b`

Made with [Cursor](https://cursor.com)