### PR TITLE
feat(stats): upgrade typography and add hairline dividers between cards

### DIFF
--- a/components/Stats.tsx
+++ b/components/Stats.tsx
@@ -15,13 +15,13 @@ export default function Stats() {
         <p className="text-xs uppercase tracking-[0.2em] text-gray-500 mb-8 text-center">
           Casting
         </p>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-8 text-center">
+        <div className="grid grid-cols-2 md:grid-cols-4 md:divide-x md:divide-gray-100 gap-y-8 md:gap-x-0 text-center">
           {stats.map(({ label, value }) => (
-            <div key={label}>
-              <p className="text-xs uppercase tracking-widest text-gray-400 mb-1">
+            <div key={label} className="md:px-4">
+              <p className="text-xs uppercase tracking-widest text-gray-400 mb-2">
                 {label}
               </p>
-              <p className="font-playfair text-2xl font-semibold text-[#222222]">
+              <p className="font-playfair text-3xl md:text-4xl font-semibold text-[#222222]">
                 {value}
               </p>
             </div>

--- a/tests/Stats.test.tsx
+++ b/tests/Stats.test.tsx
@@ -42,4 +42,19 @@ describe("Stats", () => {
     expect(section.className).toMatch(/\bborder-t\b/);
     expect(section.className).not.toMatch(/\bborder-b\b/);
   });
+
+  it("stat values use larger Playfair display size", () => {
+    const { container } = render(<Stats />);
+    const valueEls = container.querySelectorAll(".font-playfair");
+    expect(valueEls.length).toBeGreaterThan(0);
+    valueEls.forEach((el) => {
+      expect(el.className).toMatch(/text-3xl|text-4xl/);
+    });
+  });
+
+  it("stats grid has divide-x class for hairline dividers", () => {
+    const { container } = render(<Stats />);
+    const grid = container.querySelector(".grid");
+    expect(grid?.className).toMatch(/divide-x/);
+  });
 });


### PR DESCRIPTION
Closes #110

## Changes

- Upgrade stat value font size: `text-2xl` → `text-3xl md:text-4xl` for a more display-forward Playfair feel
- Add `md:divide-x md:divide-gray-100` to grid container for hairline vertical dividers on desktop only
- Switch to `gap-y-8 md:gap-x-0` so dividers sit flush; add `md:px-4` to each card

## Tests

- Stat value elements have class matching `/text-3xl|text-4xl/`
- Grid container has `divide-x` class

Made with [Cursor](https://cursor.com)