### PR TITLE
feat(stats): wrap content in FadeInOnScroll for entrance fade

### DIFF
--- a/components/Stats.tsx
+++ b/components/Stats.tsx
@@ -1,3 +1,5 @@
+import FadeInOnScroll from "./FadeInOnScroll";
+
 const stats = [
   { label: "Height", value: `6' 0"` },
   { label: "Weight", value: "185 lbs" },
@@ -11,23 +13,25 @@ export default function Stats() {
       id="stats"
       className="py-16 px-8 md:px-16 border-t border-gray-100"
     >
-      <div className="max-w-6xl mx-auto">
-        <p className="text-xs uppercase tracking-[0.2em] text-gray-500 mb-8 text-center">
-          Casting
-        </p>
-        <div className="grid grid-cols-2 md:grid-cols-4 md:divide-x md:divide-gray-100 gap-y-8 md:gap-x-0 text-center">
-          {stats.map(({ label, value }) => (
-            <div key={label} className="md:px-4">
-              <p className="text-xs uppercase tracking-widest text-gray-400 mb-2">
-                {label}
-              </p>
-              <p className="font-playfair text-3xl md:text-4xl font-semibold text-[#222222]">
-                {value}
-              </p>
-            </div>
-          ))}
+      <FadeInOnScroll>
+        <div className="max-w-6xl mx-auto">
+          <p className="text-xs uppercase tracking-[0.2em] text-gray-500 mb-8 text-center">
+            Casting
+          </p>
+          <div className="grid grid-cols-2 md:grid-cols-4 md:divide-x md:divide-gray-100 gap-y-8 md:gap-x-0 text-center">
+            {stats.map(({ label, value }) => (
+              <div key={label} className="md:px-4">
+                <p className="text-xs uppercase tracking-widest text-gray-400 mb-2">
+                  {label}
+                </p>
+                <p className="font-playfair text-3xl md:text-4xl font-semibold text-[#222222]">
+                  {value}
+                </p>
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
+      </FadeInOnScroll>
     </section>
   );
 }

--- a/tests/Stats.test.tsx
+++ b/tests/Stats.test.tsx
@@ -1,6 +1,33 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import Stats from "../components/Stats";
+
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      className,
+      initial,
+      whileInView,
+      viewport,
+      transition,
+      ...props
+    }: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any) => (
+      <div
+        className={className}
+        data-initial={JSON.stringify(initial)}
+        data-whileinview={JSON.stringify(whileInView)}
+        data-viewport={JSON.stringify(viewport)}
+        data-transition={JSON.stringify(transition)}
+        {...props}
+      >
+        {children}
+      </div>
+    ),
+  },
+  useReducedMotion: vi.fn(() => false),
+}));
 
 describe("Stats", () => {
   it("renders all four stat labels", () => {
@@ -56,5 +83,15 @@ describe("Stats", () => {
     const { container } = render(<Stats />);
     const grid = container.querySelector(".grid");
     expect(grid?.className).toMatch(/divide-x/);
+  });
+
+  it("stats content is wrapped in FadeInOnScroll", () => {
+    render(<Stats />);
+    const eyebrow = screen.getByText("Casting");
+    const fadeAncestor = eyebrow.closest("div[data-whileinview]");
+    expect(fadeAncestor).not.toBeNull();
+    expect(fadeAncestor!.getAttribute("data-whileinview")).toContain(
+      '"opacity":1'
+    );
   });
 });


### PR DESCRIPTION
Closes #111

## Changes

- Import `FadeInOnScroll` into `Stats.tsx`
- Wrap the `max-w-6xl mx-auto` inner div in `<FadeInOnScroll>` for a scroll-triggered entrance fade
- Same pattern used by About, Hero, ReelsPreview, and Headshots sections

## Tests

- framer-motion mock added to expose `data-whileinview` attribute
- Asserts that the eyebrow "Casting" has a `div[data-whileinview]` ancestor with `opacity:1` in `whileInView`

Made with [Cursor](https://cursor.com)