### PR TITLE
8.1 — Animated underline on mailto link

### DIFF
--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -7,7 +7,10 @@ export default function Contact() {
         </h2>
         <a
           href="mailto:trappedactor@gmail.com"
-          className="text-lg text-[#222222] underline underline-offset-4 hover:opacity-60 transition-opacity"
+          className="text-lg text-[#222222] relative bg-[length:0%_1px] bg-no-repeat bg-bottom hover:bg-[length:100%_1px] transition-all duration-300"
+          style={{
+            backgroundImage: "linear-gradient(currentColor, currentColor)",
+          }}
         >
           trappedactor@gmail.com
         </a>

--- a/tests/ContactFooter.test.tsx
+++ b/tests/ContactFooter.test.tsx
@@ -21,6 +21,20 @@ describe("Contact", () => {
     const link = screen.getByRole("link", { name: /trappedactor@gmail\.com/ });
     expect(link).toHaveAttribute("href", "mailto:trappedactor@gmail.com");
   });
+
+  it("mailto link uses animated underline gradient background classes", () => {
+    render(<Contact />);
+    const link = screen.getByRole("link", { name: /trappedactor@gmail\.com/ });
+    expect(link.className).toContain("bg-[length:0%_1px]");
+    expect(link.className).toContain("hover:bg-[length:100%_1px]");
+  });
+
+  it("mailto link does not use static underline utility class", () => {
+    render(<Contact />);
+    const link = screen.getByRole("link", { name: /trappedactor@gmail\.com/ });
+    const classes = link.className.split(" ");
+    expect(classes).not.toContain("underline");
+  });
 });
 
 describe("Footer", () => {


### PR DESCRIPTION
Replaces the static `underline` utility on the mailto link with a CSS gradient-background animated underline that sweeps left → right on hover (Option A from the plan).

Closes #117

Made with [Cursor](https://cursor.com)