### PR TITLE
8.2 — Copy-to-clipboard button beside the email

### DIFF
--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -1,19 +1,45 @@
+"use client";
+
+import { useState } from "react";
+
 export default function Contact() {
+  const [copied, setCopied] = useState(false);
+
+  const copyEmail = async () => {
+    try {
+      await navigator.clipboard.writeText("trappedactor@gmail.com");
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // graceful no-op if clipboard API unavailable (e.g., insecure context)
+    }
+  };
+
   return (
     <section id="contact" className="py-24 px-8 md:px-16 bg-white text-center">
       <div className="max-w-2xl mx-auto">
         <h2 className="font-playfair text-3xl md:text-4xl font-semibold text-[#222222] mb-6">
           For all bookings contact Smaran Harihar
         </h2>
-        <a
-          href="mailto:trappedactor@gmail.com"
-          className="text-lg text-[#222222] relative bg-[length:0%_1px] bg-no-repeat bg-bottom hover:bg-[length:100%_1px] transition-all duration-300"
-          style={{
-            backgroundImage: "linear-gradient(currentColor, currentColor)",
-          }}
-        >
-          trappedactor@gmail.com
-        </a>
+        <div className="flex flex-col items-center gap-3">
+          <a
+            href="mailto:trappedactor@gmail.com"
+            className="text-lg text-[#222222] relative bg-[length:0%_1px] bg-no-repeat bg-bottom hover:bg-[length:100%_1px] transition-all duration-300"
+            style={{
+              backgroundImage: "linear-gradient(currentColor, currentColor)",
+            }}
+          >
+            trappedactor@gmail.com
+          </a>
+          <button
+            type="button"
+            onClick={copyEmail}
+            className="text-xs uppercase tracking-widest text-gray-500 hover:text-[#222222] transition-colors"
+            aria-live="polite"
+          >
+            {copied ? "Copied ✓" : "Copy email"}
+          </button>
+        </div>
       </div>
     </section>
   );

--- a/tests/ContactFooter.test.tsx
+++ b/tests/ContactFooter.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import Contact from "../components/Contact";
 import Footer from "../components/Footer";
 
@@ -34,6 +34,61 @@ describe("Contact", () => {
     const link = screen.getByRole("link", { name: /trappedactor@gmail\.com/ });
     const classes = link.className.split(" ");
     expect(classes).not.toContain("underline");
+  });
+});
+
+describe("Contact — copy-to-clipboard", () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("renders a Copy email button", () => {
+    render(<Contact />);
+    expect(
+      screen.getByRole("button", { name: /copy email/i })
+    ).toBeInTheDocument();
+  });
+
+  it("clicking Copy email calls navigator.clipboard.writeText with the email", async () => {
+    render(<Contact />);
+    const button = screen.getByRole("button", { name: /copy email/i });
+    await act(async () => {
+      fireEvent.click(button);
+    });
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "trappedactor@gmail.com"
+    );
+  });
+
+  it("button label flips to Copied after click", async () => {
+    render(<Contact />);
+    const button = screen.getByRole("button", { name: /copy email/i });
+    await act(async () => {
+      fireEvent.click(button);
+    });
+    expect(screen.getByRole("button", { name: /copied/i })).toBeInTheDocument();
+  });
+
+  it("button label resets to Copy email after 2000ms", async () => {
+    render(<Contact />);
+    const button = screen.getByRole("button", { name: /copy email/i });
+    await act(async () => {
+      fireEvent.click(button);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(
+      screen.getByRole("button", { name: /copy email/i })
+    ).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
Adds a "Copy email" button below the mailto link. On click it copies `trappedactor@gmail.com` to the clipboard, shows "Copied ✓" for 2 seconds, then resets. Adds `"use client"` directive.

Closes #119

Made with [Cursor](https://cursor.com)