### PR TITLE
8.3 — 'Based in Los Angeles' subtext

### DIFF
--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -18,9 +18,10 @@ export default function Contact() {
   return (
     <section id="contact" className="py-24 px-8 md:px-16 bg-white text-center">
       <div className="max-w-2xl mx-auto">
-        <h2 className="font-playfair text-3xl md:text-4xl font-semibold text-[#222222] mb-6">
+        <h2 className="font-playfair text-3xl md:text-4xl font-semibold text-[#222222] mb-4">
           For all bookings contact Smaran Harihar
         </h2>
+        <p className="text-sm text-gray-500 mb-6">Based in Los Angeles</p>
         <div className="flex flex-col items-center gap-3">
           <a
             href="mailto:trappedactor@gmail.com"

--- a/tests/ContactFooter.test.tsx
+++ b/tests/ContactFooter.test.tsx
@@ -35,6 +35,20 @@ describe("Contact", () => {
     const classes = link.className.split(" ");
     expect(classes).not.toContain("underline");
   });
+
+  it("renders 'Based in Los Angeles' subtext", () => {
+    render(<Contact />);
+    expect(screen.getByText(/based in los angeles/i)).toBeInTheDocument();
+  });
+
+  it("subtext appears before the email link in the DOM", () => {
+    render(<Contact />);
+    const subtext = screen.getByText(/based in los angeles/i);
+    const link = screen.getByRole("link", { name: /trappedactor@gmail\.com/ });
+    expect(
+      subtext.compareDocumentPosition(link) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
 });
 
 describe("Contact — copy-to-clipboard", () => {


### PR DESCRIPTION
Adds "Based in Los Angeles" subtext between the heading and the email link per user input.

Closes #118

Made with [Cursor](https://cursor.com)