### PR TITLE
8.4 — Entrance fade via FadeInOnScroll

### DIFF
--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import FadeInOnScroll from "./FadeInOnScroll";
 
 export default function Contact() {
   const [copied, setCopied] = useState(false);
@@ -17,31 +18,33 @@ export default function Contact() {
 
   return (
     <section id="contact" className="py-24 px-8 md:px-16 bg-white text-center">
-      <div className="max-w-2xl mx-auto">
-        <h2 className="font-playfair text-3xl md:text-4xl font-semibold text-[#222222] mb-4">
-          For all bookings contact Smaran Harihar
-        </h2>
-        <p className="text-sm text-gray-500 mb-6">Based in Los Angeles</p>
-        <div className="flex flex-col items-center gap-3">
-          <a
-            href="mailto:trappedactor@gmail.com"
-            className="text-lg text-[#222222] relative bg-[length:0%_1px] bg-no-repeat bg-bottom hover:bg-[length:100%_1px] transition-all duration-300"
-            style={{
-              backgroundImage: "linear-gradient(currentColor, currentColor)",
-            }}
-          >
-            trappedactor@gmail.com
-          </a>
-          <button
-            type="button"
-            onClick={copyEmail}
-            className="text-xs uppercase tracking-widest text-gray-500 hover:text-[#222222] transition-colors"
-            aria-live="polite"
-          >
-            {copied ? "Copied ✓" : "Copy email"}
-          </button>
+      <FadeInOnScroll>
+        <div className="max-w-2xl mx-auto">
+          <h2 className="font-playfair text-3xl md:text-4xl font-semibold text-[#222222] mb-4">
+            For all bookings contact Smaran Harihar
+          </h2>
+          <p className="text-sm text-gray-500 mb-6">Based in Los Angeles</p>
+          <div className="flex flex-col items-center gap-3">
+            <a
+              href="mailto:trappedactor@gmail.com"
+              className="text-lg text-[#222222] relative bg-[length:0%_1px] bg-no-repeat bg-bottom hover:bg-[length:100%_1px] transition-all duration-300"
+              style={{
+                backgroundImage: "linear-gradient(currentColor, currentColor)",
+              }}
+            >
+              trappedactor@gmail.com
+            </a>
+            <button
+              type="button"
+              onClick={copyEmail}
+              className="text-xs uppercase tracking-widest text-gray-500 hover:text-[#222222] transition-colors"
+              aria-live="polite"
+            >
+              {copied ? "Copied ✓" : "Copy email"}
+            </button>
+          </div>
         </div>
-      </div>
+      </FadeInOnScroll>
     </section>
   );
 }

--- a/tests/ContactFooter.test.tsx
+++ b/tests/ContactFooter.test.tsx
@@ -3,6 +3,33 @@ import { render, screen, fireEvent, act } from "@testing-library/react";
 import Contact from "../components/Contact";
 import Footer from "../components/Footer";
 
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      className,
+      initial,
+      whileInView,
+      viewport,
+      transition,
+      ...props
+    }: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any) => (
+      <div
+        className={className}
+        data-initial={JSON.stringify(initial)}
+        data-whileinview={JSON.stringify(whileInView)}
+        data-viewport={JSON.stringify(viewport)}
+        data-transition={JSON.stringify(transition)}
+        {...props}
+      >
+        {children}
+      </div>
+    ),
+  },
+  useReducedMotion: () => false,
+}));
+
 describe("Contact", () => {
   it("renders a section with id contact", () => {
     render(<Contact />);
@@ -48,6 +75,16 @@ describe("Contact", () => {
     expect(
       subtext.compareDocumentPosition(link) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
+  });
+
+  it("section content is wrapped in FadeInOnScroll", () => {
+    render(<Contact />);
+    const heading = screen.getByText("For all bookings contact Smaran Harihar");
+    const fadeAncestor = heading.closest("div[data-whileinview]");
+    expect(fadeAncestor).not.toBeNull();
+    expect(fadeAncestor!.getAttribute("data-whileinview")).toContain(
+      '"opacity":1'
+    );
   });
 });
 


### PR DESCRIPTION
Wraps the contact section's inner content in `<FadeInOnScroll>` — same pattern as other sections. Adds framer-motion mock to the test file.

Closes #120

Made with [Cursor](https://cursor.com)