### PR TITLE
feat(footer): update Twitter URL to x.com

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -6,7 +6,7 @@ const socials = [
   },
   { label: "Facebook", href: "https://www.facebook.com/trappedactor/" },
   { label: "Instagram", href: "https://www.instagram.com/trappedactor/" },
-  { label: "Twitter", href: "https://twitter.com/TrappedActor" },
+  { label: "Twitter", href: "https://x.com/TrappedActor" },
 ];
 
 export default function Footer() {

--- a/tests/ContactFooter.test.tsx
+++ b/tests/ContactFooter.test.tsx
@@ -178,11 +178,11 @@ describe("Footer", () => {
     ).toContain("instagram.com/trappedactor");
   });
 
-  it("renders Twitter link", () => {
+  it("renders Twitter link pointing to x.com", () => {
     render(<Footer />);
     expect(
       screen.getByRole("link", { name: /twitter/i }).getAttribute("href")
-    ).toContain("twitter.com/TrappedActor");
+    ).toContain("x.com/TrappedActor");
   });
 
   it("does not mention Squarespace", () => {


### PR DESCRIPTION
Closes #126

Update the Twitter social link from `twitter.com/TrappedActor` to `x.com/TrappedActor` (Option A — keep the link, update the URL).

## Changes

- `components/Footer.tsx` — update Twitter href to `https://x.com/TrappedActor`
- `tests/ContactFooter.test.tsx` — update assertion to expect `x.com/TrappedActor`

## Tests

All 217 tests pass.

Made with [Cursor](https://cursor.com)