### PR TITLE
feat(footer): add copyright line and back-to-top link

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -112,6 +112,12 @@ export default function Footer() {
             ))}
           </ul>
         </div>
+        <div className="flex items-center justify-between text-xs text-gray-400">
+          <p>© {new Date().getFullYear()} Smaran Harihar</p>
+          <a href="#hero" className="hover:text-[#222222] transition-colors">
+            Back to top ↑
+          </a>
+        </div>
       </div>
     </footer>
   );

--- a/tests/ContactFooter.test.tsx
+++ b/tests/ContactFooter.test.tsx
@@ -235,6 +235,26 @@ describe("Footer", () => {
     });
   });
 
+  it("renders a copyright line with the current year and author name", () => {
+    render(<Footer />);
+    const year = new Date().getFullYear();
+    expect(
+      screen.getByText(new RegExp(`© ${year} Smaran Harihar`))
+    ).toBeInTheDocument();
+  });
+
+  it("renders a Back to top link with href #hero", () => {
+    render(<Footer />);
+    const link = screen.getByRole("link", { name: /back to top/i });
+    expect(link).toHaveAttribute("href", "#hero");
+  });
+
+  it("Back to top link text includes an up-arrow indicator", () => {
+    render(<Footer />);
+    const link = screen.getByRole("link", { name: /back to top/i });
+    expect(link.textContent).toMatch(/↑|↗|⬆/);
+  });
+
   it("all social links open in new tab", () => {
     render(<Footer />);
     const socialLinks = ["imdb", "youtube", "facebook", "instagram", "twitter"];


### PR DESCRIPTION
Closes #128

Add a second row to the footer with a dynamic copyright notice and a "Back to top" anchor link.

## Changes

- `components/Footer.tsx` — flex row below the main row: `© {year} Smaran Harihar` on left, `Back to top ↑` linking to `#hero` on right; styled `text-xs text-gray-400`
- `tests/ContactFooter.test.tsx` — 3 new tests: copyright text matches current year, back-to-top `href="#hero"`, text includes `↑`

## Tests

All 226 tests pass.

Made with [Cursor](https://cursor.com)