### PR TITLE
10.4 — robots.txt + app/sitemap.ts

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+
+export const dynamic = "force-static";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = "https://trappedactor.com";
+  return [
+    {
+      url: base,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 1,
+    },
+  ];
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://trappedactor.com/sitemap.xml


### PR DESCRIPTION
Closes #136

Adds `public/robots.txt` allowing all crawlers with Sitemap reference, and `app/sitemap.ts` using Next.js `MetadataRoute.Sitemap` for the single-page app.

**Verified:**
- `npm run build` → `out/robots.txt` ✓
- `npm run build` → `out/sitemap.xml` ✓
- `out/sitemap.xml` contains `<loc>https://trappedactor.com</loc>` ✓

Made with [Cursor](https://cursor.com)