### PR TITLE
10.2 — Remove basePath for custom domain

### DIFF
--- a/components/About.tsx
+++ b/components/About.tsx
@@ -8,7 +8,7 @@ export default function About() {
       <FadeInOnScroll className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
         <div className="relative w-full aspect-[3/4] shadow-[0_8px_30px_rgba(0,0,0,0.08)] ring-1 ring-[#e8e0d4]">
           <Image
-            src={`${process.env.NEXT_PUBLIC_BASE_PATH}/images/about.jpg`}
+            src="/images/about.jpg"
             alt="Smaran Harihar — portrait, looking off camera, soft natural light"
             fill
             className="object-cover"

--- a/components/Headshots.tsx
+++ b/components/Headshots.tsx
@@ -14,7 +14,6 @@ const headshots = [
 
 export default function Headshots() {
   const [index, setIndex] = useState(0);
-  const base = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
   const reduce = useReducedMotion();
 
   const prev = () =>
@@ -74,7 +73,7 @@ export default function Headshots() {
                 className="relative w-full max-w-2xl aspect-[3/4]"
               >
                 <Image
-                  src={`${base}${headshots[index].src}`}
+                  src={headshots[index].src}
                   alt={headshots[index].alt}
                   fill
                   sizes="(max-width: 1024px) 100vw, 672px"

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -19,7 +19,7 @@ export default function Hero() {
         transition={{ duration: reduce ? 0 : 20, ease: "easeOut" }}
       >
         <Image
-          src={`${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}/images/hero.jpg`}
+          src="/images/hero.jpg"
           alt=""
           fill
           priority

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,20 +1,14 @@
 import type { NextConfig } from "next";
 
 const isProd = process.env.NODE_ENV === "production";
-const basePath = isProd ? "/actor-portfolio" : "";
 
 const nextConfig: NextConfig = {
   ...(isProd && {
     output: "export",
-    basePath,
-    assetPrefix: basePath,
   }),
   images: {
     unoptimized: true,
     remotePatterns: [{ protocol: "https", hostname: "i.ytimg.com" }],
-  },
-  env: {
-    NEXT_PUBLIC_BASE_PATH: basePath,
   },
 };
 

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -57,13 +57,9 @@ describe("next.config", () => {
     expect(config).toContain('output: "export"');
   });
 
-  it("sets basePath /actor-portfolio for production", () => {
-    expect(config).toContain('"/actor-portfolio"');
-    expect(config).toContain("basePath");
-  });
-
-  it("sets assetPrefix /actor-portfolio for production", () => {
-    expect(config).toContain("assetPrefix");
+  it("uses custom domain so basePath is not set", () => {
+    expect(config).not.toContain("basePath");
+    expect(config).not.toContain("assetPrefix");
   });
 
   it("gates export config on production env", () => {


### PR DESCRIPTION
Closes #134

Removes `basePath`/`assetPrefix` from `next.config.ts` since `trappedactor.com` is served from the apex domain (not a GitHub Pages subpath). Removes `NEXT_PUBLIC_BASE_PATH` env var and cleans up all component usages.

**Changes:**
- `next.config.ts`: remove basePath, assetPrefix, NEXT_PUBLIC_BASE_PATH
- `components/Headshots.tsx`, `About.tsx`, `Hero.tsx`: use plain `/images/…` paths
- `tests/scaffold.test.ts`: update assertions

**All 230 tests pass.**

Made with [Cursor](https://cursor.com)