### PR TITLE
10.5 — Deploy workflow: separate build/deploy jobs, lint/typecheck/test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,9 @@
-name: Deploy to GitHub Pages
+name: Deploy
 
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -14,20 +15,29 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm run test
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: out
+
   deploy:
+    needs: build
     runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - run: npm ci && npm run build
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: out/
-      - name: Deploy to GitHub Pages
-        id: deployment
+      - id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Closes #138

Upgrades `.github/workflows/deploy.yml`:
- Adds `workflow_dispatch` trigger
- Splits into separate `build` and `deploy` jobs
- `build` runs: `npm run lint` → `npm run typecheck` → `npm run test` → `npm run build`
- Uses `actions/setup-node@v4` with `cache: "npm"` for faster CI
- Uses `actions/upload-pages-artifact@v3` + `actions/deploy-pages@v4` (modern artifact-based flow)

Made with [Cursor](https://cursor.com)