### PR TITLE
10.6 — Interaction test audit: Nav / Reels / Headshots

### DIFF
--- a/tests/Headshots.test.tsx
+++ b/tests/Headshots.test.tsx
@@ -135,6 +135,28 @@ describe("Headshots", () => {
       );
     });
 
+    it("rapid ArrowRight presses (9 presses on 4-item carousel) land on correct index", () => {
+      render(<Headshots />);
+      // 9 presses on 4-item carousel: (0 + 9) % 4 = 1 → headshot-2
+      for (let i = 0; i < 9; i++) {
+        fireEvent.keyDown(window, { key: "ArrowRight" });
+      }
+      expect(screen.getByRole("img").getAttribute("src")).toContain(
+        "headshot-2"
+      );
+    });
+
+    it("rapid ArrowLeft presses (7 presses on 4-item carousel) land on correct index", () => {
+      render(<Headshots />);
+      // 7 presses backward from 0: (0 - 7 + 28) % 4 = 21 % 4 = 1 → headshot-2
+      for (let i = 0; i < 7; i++) {
+        fireEvent.keyDown(window, { key: "ArrowLeft" });
+      }
+      expect(screen.getByRole("img").getAttribute("src")).toContain(
+        "headshot-2"
+      );
+    });
+
     it("other keys do not change the index", () => {
       render(<Headshots />);
       fireEvent.keyDown(window, { key: "Enter" });

--- a/tests/Nav.test.tsx
+++ b/tests/Nav.test.tsx
@@ -404,6 +404,29 @@ describe("Nav — hamburger aria + animation", () => {
   });
 });
 
+describe("Nav — scroll state survives overlay open/close cycle", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "scrollY", { writable: true, value: 0 });
+  });
+
+  it("returns to transparent after overlay open/close cycle when scrolled back to top", () => {
+    render(<Nav />);
+    // Scroll past threshold → glass nav
+    Object.defineProperty(window, "scrollY", { writable: true, value: 50 });
+    fireEvent.scroll(window);
+    expect(screen.getByRole("navigation").className).toMatch(/backdrop-blur/);
+    // Open then close the overlay
+    fireEvent.click(screen.getByLabelText("Open menu"));
+    fireEvent.click(screen.getByLabelText("Close menu"));
+    // Scroll back to top → nav should return to transparent
+    Object.defineProperty(window, "scrollY", { writable: true, value: 0 });
+    fireEvent.scroll(window);
+    expect(screen.getByRole("navigation").className).not.toMatch(
+      /backdrop-blur/
+    );
+  });
+});
+
 describe("Nav — focus trap + Esc + focus restoration", () => {
   it("focus moves to close button when overlay opens", () => {
     render(<Nav />);

--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -294,6 +294,35 @@ describe("ReelsPreview — modal focus and aria", () => {
   });
 });
 
+describe("ReelsPreview — Esc then re-open", () => {
+  it("opens a clean modal for a different tile after Esc closes the first", () => {
+    render(<ReelsPreview />);
+    // Open first tile
+    const firstTile = screen.getByRole("button", {
+      name: /play first responders part 1/i,
+    });
+    fireEvent.click(firstTile);
+    const iframe1 = document.querySelector("iframe");
+    expect(iframe1?.getAttribute("src")).toContain("utchWkrauZg");
+    // Close with Esc
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    // Open a different tile
+    fireEvent.click(
+      screen.getByRole("button", { name: /play being charlie/i })
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    // Confirm the iframe now shows the Being Charlie video id
+    const iframe2 = document.querySelector("iframe");
+    expect(iframe2?.getAttribute("src")).not.toContain("utchWkrauZg");
+    // Focus should be on the new close button
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: /close video/i })
+    );
+  });
+});
+
 describe("ReelsPreview — close button", () => {
   it("close button renders when modal is open", () => {
     render(<ReelsPreview />);


### PR DESCRIPTION
Closes #139

Audited `tests/Nav.test.tsx`, `tests/ReelsPreview.test.tsx`, and `tests/Headshots.test.tsx` for cross-cutting interaction gaps. Added 4 regression tests:

- **Nav**: glass state correctly resolves after overlay open/close + scroll-back-to-top cycle
- **Reels**: Esc-then-click-another-tile opens fresh modal with correct iframe and focus
- **Headshots**: 9 rapid ArrowRight presses (4-item carousel) → index 1 ✓
- **Headshots**: 7 rapid ArrowLeft presses (4-item carousel) → index 1 ✓

All 234 tests pass.

Made with [Cursor](https://cursor.com)