### PR TITLE
10.7 — Playwright + axe-core accessibility smoke suite

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,8 +32,23 @@ jobs:
         with:
           path: out
 
-  deploy:
+  e2e:
     needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:e2e
+        env:
+          CI: true
+
+  deploy:
+    needs: [build, e2e]
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/e2e/specs/accessibility.spec.ts
+++ b/e2e/specs/accessibility.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+import { HomePage } from "../pages/HomePage";
+
+test.describe("Accessibility — axe-core", () => {
+  test("home page initial load has zero violations", async ({ page }) => {
+    const home = new HomePage(page);
+    await home.goto();
+    const results = await new AxeBuilder({ page }).analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test("reels modal open state has zero violations", async ({ page }) => {
+    const home = new HomePage(page);
+    await home.goto();
+    await home.reelsSection.scrollIntoViewIfNeeded();
+    await home.reelCards.first().click();
+    await expect(home.reelDialog).toBeVisible();
+    const results = await new AxeBuilder({ page }).analyze();
+    expect(results.violations).toEqual([]);
+    await page.keyboard.press("Escape");
+    await expect(home.reelDialog).not.toBeVisible();
+  });
+
+  test("mobile nav overlay open state has zero violations", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    const home = new HomePage(page);
+    await home.goto();
+    await home.openMobileMenu();
+    await expect(home.mobileOverlay).toBeVisible();
+    const results = await new AxeBuilder({ page }).analyze();
+    expect(results.violations).toEqual([]);
+    await home.closeMobileMenu();
+  });
+
+  test("headshots carousel at index 2 has zero violations", async ({
+    page,
+  }) => {
+    const home = new HomePage(page);
+    await home.goto();
+    await home.headshotsSection.scrollIntoViewIfNeeded();
+    await home.headshotsNext.click();
+    await home.headshotsNext.click();
+    const results = await new AxeBuilder({ page }).analyze();
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react-dom": "19.2.4"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.3",
         "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
@@ -109,6 +110,19 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -3822,9 +3836,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
-      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dom": "19.2.4"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
Closes #140

Adds `@axe-core/playwright` and `e2e/specs/accessibility.spec.ts` scanning:
1. Home page initial load
2. Reels modal open state
3. Mobile nav overlay open state (375px viewport)
4. Headshots carousel at index 2

Also adds an `e2e` CI job to `.github/workflows/deploy.yml` that runs Playwright before deploy. Deploy now depends on both `build` and `e2e`.

Made with [Cursor](https://cursor.com)