### PR TITLE
10.8 — Lighthouse CI: 95-score assertions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,21 @@ jobs:
         env:
           CI: true
 
+  lighthouse:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run build
+      - run: npx serve out &
+      - run: npx wait-on http://localhost:3000
+      - run: npx @lhci/cli@0.14.x autorun
+
   deploy:
     needs: [build, e2e]
     runs-on: ubuntu-latest

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,0 +1,23 @@
+{
+  "ci": {
+    "collect": {
+      "url": ["http://localhost:3000"],
+      "numberOfRuns": 1,
+      "settings": {
+        "preset": "desktop"
+      }
+    },
+    "assert": {
+      "preset": "lighthouse:no-pwa",
+      "assertions": {
+        "categories:performance": ["warn", { "minScore": 0.95 }],
+        "categories:accessibility": ["warn", { "minScore": 0.95 }],
+        "categories:best-practices": ["warn", { "minScore": 0.95 }],
+        "categories:seo": ["warn", { "minScore": 0.95 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}


### PR DESCRIPTION
Closes #141

Adds a `lighthouse` job to `.github/workflows/deploy.yml` using `@lhci/cli@0.14.x`. Asserts ≥ 0.95 on all four Lighthouse categories (performance, accessibility, best-practices, SEO) via `.lighthouserc.json`.

- Serves `out/` with `npx serve` + `npx wait-on`
- Desktop preset, single run
- Warnings (not hard errors) initially — promote to `"error"` once baseline is established
- Uploads results to temporary-public-storage for comparison

Made with [Cursor](https://cursor.com)