### PR TITLE
10.9 — lychee link-checker CI step (non-blocking)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,22 @@ jobs:
       - run: npx wait-on http://localhost:3000
       - run: npx @lhci/cli@0.14.x autorun
 
+  link-check:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run build
+      - uses: lycheeverse/lychee-action@v2
+        with:
+          args: --verbose --no-progress out/index.html
+        continue-on-error: true
+
   deploy:
     needs: [build, e2e]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #142

Adds a `link-check` job using `lycheeverse/lychee-action@v2` scanning `out/index.html` for broken links (especially social URLs in the footer).

`continue-on-error: true` so rate-limited social sites don't block CI. Promote to blocking once the initial noise is characterized.

Made with [Cursor](https://cursor.com)