### PR TITLE
fix: image 404s, axe violations, stale e2e assertions

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -24,20 +24,20 @@ jobs:
       - name: Build
         run: npm run build
 
-  # e2e:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-node@v4
-  #       with:
-  #         node-version: 20
-  #         cache: "npm"
-  #     - run: npm ci
-  #     - run: npx playwright install --with-deps chromium
-  #     - name: E2E
-  #       run: npm run test:e2e
-  #       env:
-  #         CI: true
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - name: E2E
+        run: npm run test:e2e
+        env:
+          CI: true
 
   link-check:
     runs-on: ubuntu-latest

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -11,6 +11,7 @@ export default function About() {
             src="/images/about.jpg"
             alt="Smaran Harihar — portrait, looking off camera, soft natural light"
             fill
+            sizes="(max-width: 768px) 100vw, 50vw"
             className="object-cover"
           />
         </div>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -112,7 +112,7 @@ export default function Footer() {
             ))}
           </ul>
         </div>
-        <div className="flex items-center justify-between text-xs text-gray-400">
+        <div className="flex items-center justify-between text-xs text-gray-500">
           <p>© {new Date().getFullYear()} Smaran Harihar</p>
           <a href="#hero" className="hover:text-[#222222] transition-colors">
             Back to top ↑

--- a/components/ReelsPreview.tsx
+++ b/components/ReelsPreview.tsx
@@ -21,7 +21,7 @@ function ReelTile({
   onPlay: (id: string, btn: HTMLButtonElement) => void;
 }) {
   const [thumbSrc, setThumbSrc] = useState(
-    `https://i.ytimg.com/vi/${video.id}/maxresdefault.jpg`
+    `https://i.ytimg.com/vi/${video.id}/hqdefault.jpg`
   );
 
   return (
@@ -33,13 +33,10 @@ function ReelTile({
       <div className="relative overflow-hidden aspect-video bg-black">
         <Image
           src={thumbSrc}
-          alt={video.title}
+          alt=""
           fill
           sizes="(max-width: 640px) 100vw, 50vw"
           className="object-cover group-hover:scale-[1.02] transition-transform duration-300"
-          onError={() =>
-            setThumbSrc(`https://i.ytimg.com/vi/${video.id}/hqdefault.jpg`)
-          }
         />
         <div className="absolute inset-0 flex items-center justify-center">
           <div className="w-14 h-14 rounded-full bg-white/80 flex items-center justify-center transition-all duration-200 group-hover:scale-110 group-hover:bg-white group-hover:ring-2 group-hover:ring-white/40">

--- a/e2e/pages/HomePage.ts
+++ b/e2e/pages/HomePage.ts
@@ -99,11 +99,11 @@ export class HomePage {
     return this.headshotsSection.getByRole("img");
   }
   /**
-   * The "1 / 4" indicator text. Returned as the matching paragraph
-   * locator so callers can assert text and visibility.
+   * The carousel position indicator paragraph (aria-live region).
+   * Accessible text comes from the sr-only span: "Image N of 4".
    */
   get headshotsIndicator(): Locator {
-    return this.headshotsSection.getByText(/^\s*\d+\s*\/\s*\d+\s*$/);
+    return this.headshotsSection.locator("p[aria-live]");
   }
 
   // --- Contact ----------------------------------------------------------

--- a/e2e/specs/accessibility.spec.ts
+++ b/e2e/specs/accessibility.spec.ts
@@ -16,7 +16,9 @@ test.describe("Accessibility — axe-core", () => {
     await home.reelsSection.scrollIntoViewIfNeeded();
     await home.reelCards.first().click();
     await expect(home.reelDialog).toBeVisible();
-    const results = await new AxeBuilder({ page }).analyze();
+    // Exclude the YouTube iframe — its internal player DOM uses aria-label
+    // on a div without a role, which is third-party markup we can't control.
+    const results = await new AxeBuilder({ page }).exclude("iframe").analyze();
     expect(results.violations).toEqual([]);
     await page.keyboard.press("Escape");
     await expect(home.reelDialog).not.toBeVisible();
@@ -42,7 +44,9 @@ test.describe("Accessibility — axe-core", () => {
     await home.goto();
     await home.headshotsSection.scrollIntoViewIfNeeded();
     await home.headshotsNext.click();
+    await expect(home.headshotsIndicator).toContainText("Image 2 of 4");
     await home.headshotsNext.click();
+    await expect(home.headshotsIndicator).toContainText("Image 3 of 4");
     const results = await new AxeBuilder({ page }).analyze();
     expect(results.violations).toEqual([]);
   });

--- a/e2e/specs/headshots.spec.ts
+++ b/e2e/specs/headshots.spec.ts
@@ -9,7 +9,7 @@ test.describe("Headshots carousel", () => {
 
     await expect(home.headshotsImage).toBeVisible();
     await expect(home.headshotsImage).toHaveAccessibleName(/headshot 1/i);
-    await expect(home.headshotsIndicator).toHaveText("1 / 4");
+    await expect(home.headshotsIndicator).toContainText("Image 1 of 4");
   });
 
   test("Next advances the carousel to the second headshot", async ({
@@ -20,7 +20,7 @@ test.describe("Headshots carousel", () => {
     await home.headshotsSection.scrollIntoViewIfNeeded();
 
     await home.headshotsNext.click();
-    await expect(home.headshotsIndicator).toHaveText("2 / 4");
+    await expect(home.headshotsIndicator).toContainText("Image 2 of 4");
     await expect(home.headshotsImage).toHaveAccessibleName(/headshot 2/i);
   });
 
@@ -30,7 +30,7 @@ test.describe("Headshots carousel", () => {
     await home.headshotsSection.scrollIntoViewIfNeeded();
 
     await home.headshotsPrev.click();
-    await expect(home.headshotsIndicator).toHaveText("4 / 4");
+    await expect(home.headshotsIndicator).toContainText("Image 4 of 4");
     await expect(home.headshotsImage).toHaveAccessibleName(/headshot 4/i);
   });
 

--- a/e2e/specs/nav.spec.ts
+++ b/e2e/specs/nav.spec.ts
@@ -6,7 +6,7 @@ test.describe("Nav — desktop", () => {
     const home = new HomePage(page);
     await home.goto();
     await expect(home.siteTitle).toBeVisible();
-    await expect(home.siteTitle).toHaveAttribute("href", "/#");
+    await expect(home.siteTitle).toHaveAttribute("href", "#hero");
   });
 
   test("active-section underline appears when a section is in view", async ({

--- a/tests/ReelsPreview.test.tsx
+++ b/tests/ReelsPreview.test.tsx
@@ -92,26 +92,27 @@ describe("ReelsPreview — tiles", () => {
 
   it("renders a thumbnail for each video", () => {
     render(<ReelsPreview />);
-    const thumbnails = screen.getAllByRole("img");
+    const thumbnails = document.querySelectorAll("img[src*='ytimg.com']");
     expect(thumbnails.length).toBeGreaterThanOrEqual(4);
-    expect(thumbnails[0].getAttribute("src")).toContain("ytimg.com");
   });
 
-  it("thumbnails use maxresdefault as default src", () => {
+  it("thumbnails use hqdefault as default src", () => {
     render(<ReelsPreview />);
-    const thumbnails = screen.getAllByRole("img");
-    expect(thumbnails[0].getAttribute("src")).toContain("maxresdefault.jpg");
+    const thumbnails = document.querySelectorAll("img[src*='ytimg.com']");
+    expect(thumbnails[0].getAttribute("src")).toContain("hqdefault.jpg");
   });
 
-  it("thumbnail alt matches the video title", () => {
+  it("thumbnail images are decorative (empty alt, role presentation)", () => {
     render(<ReelsPreview />);
-    expect(screen.getByAltText("First Responders Part 1")).toBeInTheDocument();
-    expect(screen.getByAltText("Being Charlie")).toBeInTheDocument();
+    const thumbnails = document.querySelectorAll("img[src*='ytimg.com']");
+    thumbnails.forEach((img) => {
+      expect(img.getAttribute("alt")).toBe("");
+    });
   });
 
   it("thumbnails use Next.js Image component (sizes prop present)", () => {
     render(<ReelsPreview />);
-    const thumbnails = screen.getAllByRole("img");
+    const thumbnails = document.querySelectorAll("img[src*='ytimg.com']");
     expect(thumbnails[0]).toHaveAttribute("sizes");
   });
 
@@ -170,13 +171,13 @@ describe("ReelsPreview — tiles", () => {
 
   it("thumbnail Image has hover scale class", () => {
     render(<ReelsPreview />);
-    const thumbnail = screen.getAllByRole("img")[0];
+    const thumbnail = document.querySelector("img[src*='ytimg.com']")!;
     expect(thumbnail.className).toMatch(/group-hover:scale-/);
   });
 
   it("thumbnail Image has transition class", () => {
     render(<ReelsPreview />);
-    const thumbnail = screen.getAllByRole("img")[0];
+    const thumbnail = document.querySelector("img[src*='ytimg.com']")!;
     expect(thumbnail.className).toMatch(/transition-/);
   });
 });


### PR DESCRIPTION
Refs #156

Fixes 10 of 11 failing e2e tests. One remaining: hero snapshot baseline (handled in a separate sub-PR).

## Changes

**Components**
- `ReelsPreview.tsx` — default thumbnail to `hqdefault.jpg` (eliminates 404 console errors for video IDs without maxresdefault); set `alt=""` on decorative thumbnail images
- `About.tsx` — add missing `sizes` prop to suppress next/image console warning
- `Footer.tsx` — `text-gray-400` → `text-gray-500` to pass WCAG AA color contrast (2.6 → 4.6:1)

**CI**
- `review.yml` — uncomment e2e job so Playwright runs on PRs

**E2E tests (assertions updated to match current component output)**
- `nav.spec.ts` — site title href: `"/#"` → `"#hero"`
- `headshots.spec.ts` — indicator text: `"N / 4"` → `"Image N of 4"`
- `accessibility.spec.ts` — exclude YouTube iframe from axe; add indicator guards to prevent carousel animation race

**Page object**
- `HomePage.ts` — `headshotsIndicator` locator: stale regex → `p[aria-live]`

**Unit tests**
- `ReelsPreview.test.tsx` — align with `alt=""` and `hqdefault` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)