### PR TITLE
chore: update skill files for closing keywords, branch guard, and mer…

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -9,7 +9,19 @@ Combines `/setup-pre-commit` and `/typo-check` into one step.
 
 ## Steps
 
-### 1. Ensure pre-commit hooks are set up
+### 1. Check current branch
+
+Run `git branch --show-current`.
+
+If the current branch is `main`, derive a branch name from the staged/unstaged changes (slugified summary, e.g. `fix-implement-plan-closing-keywords`) and create it:
+
+```bash
+git checkout -b <branch-name>
+```
+
+Then continue to step 2.
+
+### 2. Ensure pre-commit hooks are set up
 
 Check whether Husky + lint-staged are already configured:
 
@@ -22,7 +34,7 @@ If **all** are present, skip to step 2.
 
 If **any** are missing, run `/setup-pre-commit` in full before continuing.
 
-### 2. Typo check and commit
+### 3. Typo check and commit
 
 Run `/typo-check` — this will:
 

--- a/.claude/skills/implement-plan/SKILL.md
+++ b/.claude/skills/implement-plan/SKILL.md
@@ -65,7 +65,9 @@ git checkout -b <sub-branch-name>
 
 **4f. Create sub-PR** targeting the primary branch, linked to its GitHub issue.
 
-Include a closing keyword (`Closes #<issue-number>`) in the PR body so GitHub auto-links and auto-closes the issue when the sub-PR is merged. Use the issue number identified in Step 1 / 1a.
+Include a closing keyword for each issue in the PR body so GitHub auto-links and auto-closes the issue when the sub-PR is merged. Use the issue number identified in Step 1 / 1a.
+
+Each issue **must be on its own line** — GitHub only closes issues when each closing keyword appears on a separate line. Do NOT combine them (`Closes #134, #135` only closes #134).
 
 ```bash
 gh pr create \
@@ -74,7 +76,14 @@ gh pr create \
   --body "Closes #<issue-number>"
 ```
 
-If the issue cannot be auto-closed by the sub-PR (e.g., it spans multiple sub-PRs), use `Refs #<issue-number>` instead so the link is recorded without closing.
+When a sub-PR resolves multiple issues, list each on its own line:
+
+```
+Closes #134
+Closes #135
+```
+
+If the issue cannot be auto-closed by the sub-PR (e.g., it spans multiple sub-PRs), use `Refs #<issue-number>` instead — one per line — so the link is recorded without closing.
 
 **4g. Merge sub-PR** into the primary branch.
 

--- a/.claude/skills/merge-to-main/SKILL.md
+++ b/.claude/skills/merge-to-main/SKILL.md
@@ -49,8 +49,26 @@ gh pr merge <PR-number> --squash --subject "<subject>" --body "<body>"
 - Find the open PR for the current branch with `gh pr view`.
 - If no PR exists, create one first with `gh pr create`.
 - Write the commit subject and body using the `/typo-check` message format: one-line subject summarizing all changes, then a `### file` section per changed file with bullet points.
-- Pull main locally after merge to sync: `git checkout main && git pull origin main`.
 
-### 6. Confirm
+### 6. Switch to main and sync
 
-Print the merge commit SHA and confirm main is up to date.
+```bash
+git checkout main
+git pull origin main
+```
+
+### 7. Delete the merged branch
+
+Delete the remote branch first, then the local branch:
+
+```bash
+git push origin --delete <branch>
+git branch -D <branch>
+```
+
+- Delete the remote branch with `git push origin --delete <branch>`. If GitHub already auto-deleted it (repo setting), this is a no-op — ignore the error.
+- Use `git branch -D` (force delete) because squash merges aren't tracked by git's safe `-d` check.
+
+### 8. Confirm
+
+Print the merge commit SHA and confirm main is up to date and the branch is gone.


### PR DESCRIPTION
…ge cleanup

### .claude/skills/implement-plan/SKILL.md
- Require each `Closes #N` on its own line in sub-PR bodies (GitHub only closes issues when each keyword is on a separate line)
- Add explicit warning against combining multiple issues on one line
- Show correct multi-issue format example

### .claude/skills/commit/SKILL.md
- Add step 1: if current branch is `main`, create a new branch derived from the pending changes before committing
- Renumber remaining steps (2, 3)

### .claude/skills/merge-to-main/SKILL.md
- Expand step 6 to switch to main and pull after merge
- Add step 7 to delete the merged branch (remote then local)
- Renumber confirm step to 8